### PR TITLE
Change label from name to title

### DIFF
--- a/src/main/webapp/app/entities/study/study-dialog.component.html
+++ b/src/main/webapp/app/entities/study/study-dialog.component.html
@@ -8,7 +8,7 @@
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>
         <div class="form-group">
-            <label class="form-control-label" for="field_name">Name</label>
+            <label class="form-control-label" for="field_name">Title</label>
             <input type="text" class="form-control" name="name" id="field_name"
                 [(ngModel)]="study.name" required />
             <div [hidden]="!(editForm.controls.name?.dirty && editForm.controls.name?.invalid)">


### PR DESCRIPTION
This fixes issue #1 

The label on the create study/edit study pages for the first input box was changed from 'Name' to 'Title'