### PR TITLE
Add Facebook login keys and fix integration

### DIFF
--- a/src/main/java/org/project36/qualopt/service/SocialService.java
+++ b/src/main/java/org/project36/qualopt/service/SocialService.java
@@ -21,6 +21,10 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import javax.annotation.PostConstruct;
+
 @Service
 public class SocialService {
 
@@ -126,5 +130,37 @@ public class SocialService {
     private void createSocialConnection(String login, Connection<?> connection) {
         ConnectionRepository connectionRepository = usersConnectionRepository.createConnectionRepository(login);
         connectionRepository.addConnection(connection);
+    }
+
+    // Reflective method to prevent the Facebook connection from picking invalid fields when fetching user data
+    @PostConstruct
+    private void init() {
+        try {
+            String[] fieldsToMap = { "id", "about", "age_range", "birthday",
+                    "context", "cover", "currency", "devices", "education",
+                    "email", "favorite_athletes", "favorite_teams",
+                    "first_name", "gender", "hometown", "inspirational_people",
+                    "installed", "install_type", "is_verified", "languages",
+                    "last_name", "link", "locale", "location", "meeting_for",
+                    "middle_name", "name", "name_format", "political",
+                    "quotes", "payment_pricepoints", "relationship_status",
+                    "religion", "security_settings", "significant_other",
+                    "sports", "test_group", "timezone", "third_party_id",
+                    "updated_time", "verified", "viewer_can_send_gift",
+                    "website", "work" };
+
+            Field field = Class.forName(
+                    "org.springframework.social.facebook.api.UserOperations")
+                    .getDeclaredField("PROFILE_FIELDS");
+            field.setAccessible(true);
+
+            Field modifiers = field.getClass().getDeclaredField("modifiers");
+            modifiers.setAccessible(true);
+            modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            field.set(null, fieldsToMap);
+
+        } catch (Exception e) {
+            log.error("Failed to update user info fields for the facebook api connector", e);
+        }
     }
 }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -53,8 +53,8 @@ spring:
 
         # see https://developers.facebook.com/docs/facebook-login/v2.2
         facebook:
-            client-id: xxx
-            client-secret: xxx
+            client-id: 1703434426389778
+            client-secret: 12a4ba62e573d9b78b4636d4dd3a497d
 
         # see https://apps.twitter.com/app/
         twitter:


### PR DESCRIPTION
Fixes #22 

There was no access keys for Facebook - development keys were made and **Facebook login works only on localhost:8080**

In production these keys should be removed from the config and some secrets mechanism should be used.

Fetching user info from the Facebook API when creating a new user throws an error on some invalid fields - The workaround we use is a reflective method to update the valid `PROFILE_FIELD` values we're concerned with when querying the facebook API.

New sign in flow:

1. Click "Sign in with Facebook".
2. (If new user) show "Created account" page. Clicking the sign in button again will go to step 3.
3. User is signed in with their avatar and name visible.

