### PR TITLE
Remove extra information from post registration screen

### DIFF
--- a/src/main/webapp/app/account/register/register.component.html
+++ b/src/main/webapp/app/account/register/register.component.html
@@ -113,16 +113,16 @@
                 <button type="submit" [disabled]="registerForm.form.invalid" class="btn btn-primary">Register</button>
             </form>
             <p></p>
-            <div class="alert alert-warning">
+            <div class="alert alert-warning" *ngIf="!success">
                 <span>If you want to </span>
                 <a class="alert-link" (click)="openLogin()">sign in</a><span>, you can try the default account:<br/>- User (login="user" and password="user").</span>
             </div>
         </div>
         <div class="col-md-4">
             <br/>
-            <jhi-social provider="google"></jhi-social>
-            <jhi-social provider="facebook"></jhi-social>
-            <jhi-social provider="twitter"></jhi-social>
+            <jhi-social *ngIf="!success" provider="google"></jhi-social>
+            <jhi-social *ngIf="!success" provider="facebook"></jhi-social>
+            <jhi-social *ngIf="!success" provider="twitter"></jhi-social>
             <!-- jhipster-needle-add-social-button -->
         </div>
     </div>


### PR DESCRIPTION
As per #10 

If the registration is successful the google/twitter/facebook logins and the default account message are not displayed. 