### PR TITLE
Delete within study screen

### DIFF
--- a/src/main/webapp/app/entities/study/study-delete-dialog.component.ts
+++ b/src/main/webapp/app/entities/study/study-delete-dialog.component.ts
@@ -34,6 +34,7 @@ export class StudyDeleteDialogComponent {
                 content: 'Deleted an study'
             });
             this.activeModal.dismiss(true);
+            window.history.back();
         });
     }
 }

--- a/src/main/webapp/app/entities/study/study-detail.component.html
+++ b/src/main/webapp/app/entities/study/study-detail.component.html
@@ -53,5 +53,4 @@
             class="btn btn-success">
         <span class="fa fa-paper-plane"></span>&nbsp;<span> Send Invitation</span>
     </button>
-
 </div>

--- a/src/main/webapp/app/entities/study/study-detail.component.html
+++ b/src/main/webapp/app/entities/study/study-detail.component.html
@@ -40,10 +40,18 @@
         <span class="fa fa-pencil"></span>&nbsp;<span> Edit</span>
     </button>
 
+    <button type="submit"
+            [routerLink]="['/', { outlets: { popup: 'study/'+ study.id + '/delete'} }]"
+            replaceUrl="true"
+            class="btn btn-danger">
+        <span class="fa fa-remove"></span>&nbsp;<span class="hidden-md-down">Delete</span>
+    </button>
+
     <button type="button"
             [routerLink]="['#']"
             replaceUrl="true"
             class="btn btn-success">
         <span class="fa fa-paper-plane"></span>&nbsp;<span> Send Invitation</span>
     </button>
+
 </div>


### PR DESCRIPTION
Add option to delete study from within individual study screen #17

"Currently, a study can only be deleted from the overall study screen. A user would likely want to be able to delete the study from the individual study screen too so they can have multiple options of where to click from."

Added a delete button within individual study page and after the individual study is deleted redirect back to the overall studies page.