### PR TITLE
Fix second and third typos in project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Before you can build this project, you must install and configure the following 
 2. [Yarn][]: We use Yarn to manage Node dependencies.
    Depending on your system, you can install Yarn either from source or as a pre-packaged bundle.
 
-**Warning QualOpt cannot be run on Java 9 as there is an error with Spring. Jave 8 or earlier required.**
+**Warning QualOpt cannot be run on Java 9 as there is an error with Spring. Java 8 or earlier required.**
 
 After installing Node, you should be able to run the following command to install development tools (try `npm install` if you have problems).
 You will only need to run this command when dependencies change in [package.json](package.json).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We use yarn scripts and [Webpack][] as our build system.
 Run the following commands in two separate terminals to create a blissful development experience where your browser
 auto-refreshes when files change on your hard drive.
 
-    ./mvnw [just mvnw on cmd enviroments]
+    ./mvnw [just mvnw on cmd environments]
     yarn start
 
 [Yarn][] is also used to manage CSS and JavaScript dependencies used in this application. You can upgrade dependencies by


### PR DESCRIPTION
Fix a second typo in the readme as raised in #47. The typo is in the word "Jave" which should be "Java".