### PR TITLE
Link Service to Send Invitation button; now sends out emails

### DIFF
--- a/src/main/java/org/project36/qualopt/service/MailService.java
+++ b/src/main/java/org/project36/qualopt/service/MailService.java
@@ -1,10 +1,10 @@
 package org.project36.qualopt.service;
 
-import io.github.jhipster.config.JHipsterProperties;
-import org.apache.commons.lang3.CharEncoding;
-import org.apache.commons.lang3.StringUtils;
-import org.project36.qualopt.domain.Study;
 import org.project36.qualopt.domain.User;
+
+import io.github.jhipster.config.JHipsterProperties;
+
+import org.apache.commons.lang3.CharEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
@@ -14,10 +14,10 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring4.SpringTemplateEngine;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.mail.internet.MimeMessage;
 import java.util.Locale;
-import java.util.Objects;
 
 /**
  * Service for sending emails.
@@ -83,6 +83,7 @@ public class MailService {
         String content = templateEngine.process(templateName, context);
         String subject = messageSource.getMessage(titleKey, null, locale);
         sendEmail(user.getEmail(), subject, content, false, true);
+
     }
 
     @Async
@@ -113,15 +114,5 @@ public class MailService {
         String content = templateEngine.process("socialRegistrationValidationEmail", context);
         String subject = messageSource.getMessage("email.social.registration.title", null, locale);
         sendEmail(user.getEmail(), subject, content, false, true);
-    }
-
-    @Async
-    public void sendInvitationEmail(Study study){
-        log.debug("Sending invitation email for '{}", study.getEmailSubject());
-
-        String subject = study.getEmailSubject();
-        String content = Objects.isNull(study.getEmailBody()) ? "" : study.getEmailBody();
-        study.getParticipants().forEach(participant ->
-            sendEmail(participant.getEmail(), subject, content, false, true));
     }
 }

--- a/src/main/java/org/project36/qualopt/service/MailService.java
+++ b/src/main/java/org/project36/qualopt/service/MailService.java
@@ -1,10 +1,10 @@
 package org.project36.qualopt.service;
 
-import org.project36.qualopt.domain.User;
-
 import io.github.jhipster.config.JHipsterProperties;
-
 import org.apache.commons.lang3.CharEncoding;
+import org.apache.commons.lang3.StringUtils;
+import org.project36.qualopt.domain.Study;
+import org.project36.qualopt.domain.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
@@ -14,10 +14,10 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring4.SpringTemplateEngine;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.mail.internet.MimeMessage;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * Service for sending emails.
@@ -83,7 +83,6 @@ public class MailService {
         String content = templateEngine.process(templateName, context);
         String subject = messageSource.getMessage(titleKey, null, locale);
         sendEmail(user.getEmail(), subject, content, false, true);
-
     }
 
     @Async
@@ -114,5 +113,15 @@ public class MailService {
         String content = templateEngine.process("socialRegistrationValidationEmail", context);
         String subject = messageSource.getMessage("email.social.registration.title", null, locale);
         sendEmail(user.getEmail(), subject, content, false, true);
+    }
+
+    @Async
+    public void sendInvitationEmail(Study study){
+        log.debug("Sending invitation email for '{}", study.getEmailSubject());
+
+        String subject = study.getEmailSubject();
+        String content = Objects.isNull(study.getEmailBody()) ? "" : study.getEmailBody();
+        study.getParticipants().forEach(participant ->
+            sendEmail(participant.getEmail(), subject, content, false, true));
     }
 }

--- a/src/main/java/org/project36/qualopt/service/StudyService.java
+++ b/src/main/java/org/project36/qualopt/service/StudyService.java
@@ -1,0 +1,67 @@
+package org.project36.qualopt.service;
+
+import org.project36.qualopt.domain.Study;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import javax.mail.*;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.util.Objects;
+import java.util.Properties;
+
+@Service
+public class StudyService {
+
+    private static final Logger log = LoggerFactory.getLogger(StudyService.class);
+
+    @Async
+    public void sendInvitationEmail(Study study){
+        log.debug("Sending invitation email for study '{}'", study);
+
+        String subject = study.getEmailSubject();
+        String content = Objects.isNull(study.getEmailBody()) ? "" : study.getEmailBody();
+        String userEmail = study.getUser().getEmail();
+        try {
+            MimeMessage message = new MimeMessage(getUserEmailSession());
+            message.setFrom(new InternetAddress(userEmail));
+            message.addRecipients(Message.RecipientType.TO, study
+                .getParticipants()
+                .stream()
+                .map(participant -> {
+                    try {
+                        return new InternetAddress(participant.getEmail());
+                    } catch (AddressException e) {
+                        log.error("Failed to create internet address from participant email", e);
+                        throw new RuntimeException(e);
+                    }
+                })
+                .toArray(Address[]::new));
+            message.setSubject(subject);
+            message.setText(content);
+            Transport.send(message);
+            log.debug("Sent invitation email for study '{}'", study);
+        } catch (MessagingException e) {
+            log.error("Failed to send invitation email", e);
+        }
+    }
+
+    private Session getUserEmailSession(){
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.host", "smtp.gmail.com");
+        props.put("mail.smtp.port", "587");
+        return Session.getInstance(props,
+            new javax.mail.Authenticator() {
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    // dev test gmail account for proof of concept
+                    // TODO authenticate user email and use that instead. i.e. study.getUser().getEmail()
+                    return new PasswordAuthentication("tt7199425@gmail.com", "testemail123");
+                }
+            });
+    }
+}

--- a/src/main/java/org/project36/qualopt/service/StudyService.java
+++ b/src/main/java/org/project36/qualopt/service/StudyService.java
@@ -55,6 +55,8 @@ public class StudyService {
         props.put("mail.smtp.starttls.enable", "true");
         props.put("mail.smtp.host", "smtp.gmail.com");
         props.put("mail.smtp.port", "587");
+        // trust the host gmail; prevents antivirus from blocking emails being sent
+        props.put("mail.smtp.ssl.trust", "smtp.gmail.com");
         return Session.getInstance(props,
             new javax.mail.Authenticator() {
                 protected PasswordAuthentication getPasswordAuthentication() {

--- a/src/main/java/org/project36/qualopt/web/rest/StudyResource.java
+++ b/src/main/java/org/project36/qualopt/web/rest/StudyResource.java
@@ -7,7 +7,7 @@ import org.project36.qualopt.domain.Study;
 import org.project36.qualopt.domain.User;
 import org.project36.qualopt.repository.StudyRepository;
 import org.project36.qualopt.repository.UserRepository;
-import org.project36.qualopt.service.MailService;
+import org.project36.qualopt.service.StudyService;
 import org.project36.qualopt.web.rest.util.HeaderUtil;
 import org.project36.qualopt.web.rest.util.PaginationUtil;
 import org.slf4j.Logger;
@@ -41,15 +41,15 @@ public class StudyResource {
 
     private static final String ENTITY_NAME = "study";
 
-    private final MailService mailService;
+    private final StudyService studyService;
 
     private final UserRepository UserRepository;
 
     private final StudyRepository studyRepository;
 
-    public StudyResource(StudyRepository studyRepository, MailService mailService, UserRepository UserRepository) {
+    public StudyResource(StudyRepository studyRepository, StudyService studyService, UserRepository UserRepository) {
         this.studyRepository = studyRepository;
-        this.mailService = mailService;
+        this.studyService = studyService;
         this.UserRepository = UserRepository;
     }
 
@@ -170,7 +170,7 @@ public class StudyResource {
         if (Objects.isNull(study)){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
-        mailService.sendInvitationEmail(study);
+        studyService.sendInvitationEmail(study);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 }

--- a/src/main/webapp/app/entities/study/study-detail.component.html
+++ b/src/main/webapp/app/entities/study/study-detail.component.html
@@ -41,8 +41,7 @@
     </button>
 
     <button type="button"
-            [routerLink]="['#']"
-            replaceUrl="true"
+            (click)="sendInvitation()"
             class="btn btn-success">
         <span class="fa fa-paper-plane"></span>&nbsp;<span> Send Invitation</span>
     </button>

--- a/src/main/webapp/app/entities/study/study-detail.component.ts
+++ b/src/main/webapp/app/entities/study/study-detail.component.ts
@@ -36,6 +36,7 @@ export class StudyDetailComponent implements OnInit, OnDestroy {
             this.study = study;
         });
     }
+
     byteSize(field) {
         return this.dataUtils.byteSize(field);
     }
@@ -43,8 +44,13 @@ export class StudyDetailComponent implements OnInit, OnDestroy {
     openFile(contentType, field) {
         return this.dataUtils.openFile(contentType, field);
     }
+
     previousState() {
         window.history.back();
+    }
+
+    sendInvitation() {
+        this.studyService.send(this.study).subscribe();
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/entities/study/study.service.ts
+++ b/src/main/webapp/app/entities/study/study.service.ts
@@ -42,6 +42,10 @@ export class StudyService {
         return this.http.delete(`${this.resourceUrl}/${id}`);
     }
 
+    send(study: Study): Observable<any> {
+        return this.http.post(`${this.resourceUrl}/send`, study);
+    }
+
     private convertResponse(res: Response): ResponseWrapper {
         const jsonResponse = res.json();
         return new ResponseWrapper(res.headers, jsonResponse, res.status);

--- a/src/test/java/org/project36/qualopt/service/StudyServiceIntTest.java
+++ b/src/test/java/org/project36/qualopt/service/StudyServiceIntTest.java
@@ -1,0 +1,64 @@
+package org.project36.qualopt.service;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.project36.qualopt.QualOptApp;
+import org.project36.qualopt.domain.Participant;
+import org.project36.qualopt.domain.Study;
+import org.project36.qualopt.domain.User;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = QualOptApp.class)
+public class StudyServiceIntTest {
+
+    private StudyService studyService;
+
+    @Spy
+    private JavaMailSenderImpl javaMailSender;
+
+    @Captor
+    private ArgumentCaptor messageCaptor;
+
+    @Before
+    public void setup() throws MessagingException {
+        MockitoAnnotations.initMocks(this);
+        doNothing().when(javaMailSender).send(any(MimeMessage.class));
+        studyService = new StudyService(javaMailSender);
+    }
+
+    @Test
+    public void testSendInvitationEmail() throws Exception {
+        User user = new User();
+        user.setEmail("user@email.com");
+        studyService.sendInvitationEmail(new Study()
+            .user(user)
+            .emailSubject("testSubject")
+            .emailBody("testContent")
+            .participants(ImmutableSet.of(new Participant().email("participant@email.com"))));
+        verify(javaMailSender).send((MimeMessage) messageCaptor.capture());
+        MimeMessage message = (MimeMessage) messageCaptor.getValue();
+        assertThat(message.getSubject()).isEqualTo("testSubject");
+        assertThat(message.getAllRecipients()[0].toString()).isEqualTo("participant@email.com");
+        assertThat(message.getFrom()[0].toString()).isEqualTo("user@email.com");
+        assertThat(message.getContent()).isInstanceOf(String.class);
+        assertThat(message.getContent().toString()).isEqualTo("testContent");
+        assertThat(message.getDataHandler().getContentType()).isEqualTo("text/plain; charset=UTF-8");
+    }
+}

--- a/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
+++ b/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
@@ -1,9 +1,12 @@
 package org.project36.qualopt.web.rest;
 
+import org.mockito.Mock;
 import org.project36.qualopt.QualOptApp;
 
 import org.project36.qualopt.domain.Study;
 import org.project36.qualopt.repository.StudyRepository;
+import org.project36.qualopt.repository.UserRepository;
+import org.project36.qualopt.service.MailService;
 import org.project36.qualopt.web.rest.errors.ExceptionTranslator;
 
 import org.junit.Before;
@@ -19,7 +22,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Base64Utils;
 
 import javax.persistence.EntityManager;
 import java.util.List;
@@ -57,6 +59,9 @@ public class StudyResourceIntTest {
     private StudyRepository studyRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private MappingJackson2HttpMessageConverter jacksonMessageConverter;
 
     @Autowired
@@ -72,10 +77,13 @@ public class StudyResourceIntTest {
 
     private Study study;
 
+    @Mock
+    private MailService mockMailService;
+
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        StudyResource studyResource = new StudyResource(studyRepository);
+        StudyResource studyResource = new StudyResource(studyRepository, mockMailService, userRepository);
         this.restStudyMockMvc = MockMvcBuilders.standaloneSetup(studyResource)
             .setCustomArgumentResolvers(pageableArgumentResolver)
             .setControllerAdvice(exceptionTranslator)

--- a/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
+++ b/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
@@ -1,18 +1,16 @@
 package org.project36.qualopt.web.rest;
 
-import org.mockito.Mock;
-import org.project36.qualopt.QualOptApp;
-
-import org.project36.qualopt.domain.Study;
-import org.project36.qualopt.repository.StudyRepository;
-import org.project36.qualopt.repository.UserRepository;
-import org.project36.qualopt.service.MailService;
-import org.project36.qualopt.web.rest.errors.ExceptionTranslator;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.project36.qualopt.QualOptApp;
+import org.project36.qualopt.domain.Study;
+import org.project36.qualopt.repository.StudyRepository;
+import org.project36.qualopt.repository.UserRepository;
+import org.project36.qualopt.service.StudyService;
+import org.project36.qualopt.web.rest.errors.ExceptionTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
@@ -27,7 +25,6 @@ import javax.persistence.EntityManager;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -78,12 +75,12 @@ public class StudyResourceIntTest {
     private Study study;
 
     @Mock
-    private MailService mockMailService;
+    private StudyService mockStudyService;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        StudyResource studyResource = new StudyResource(studyRepository, mockMailService, userRepository);
+        StudyResource studyResource = new StudyResource(studyRepository, mockStudyService, userRepository);
         this.restStudyMockMvc = MockMvcBuilders.standaloneSetup(studyResource)
             .setCustomArgumentResolvers(pageableArgumentResolver)
             .setControllerAdvice(exceptionTranslator)

--- a/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
+++ b/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
@@ -25,6 +25,8 @@ import javax.persistence.EntityManager;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -315,5 +317,15 @@ public class StudyResourceIntTest {
         assertThat(study1).isNotEqualTo(study2);
         study1.setId(null);
         assertThat(study1).isNotEqualTo(study2);
+    }
+
+    @Test
+    @Transactional
+    public void sendStudy() throws Exception {
+        doNothing().when(mockStudyService).sendInvitationEmail(any(Study.class));
+        restStudyMockMvc.perform(post("/api/studies/send")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(study)))
+            .andExpect(status().isCreated());
     }
 }


### PR DESCRIPTION
Solution to #71 
- Created a new REST endpoint POST /api/studies/send in StudyResource using new StudyService object
- Created a new method StudyService#sendInvitationEmail(Study) 
- Linked POST endpoint to Send Invitation button via study-detail.component#sendInvitation() and study.service#send().

Currently using a test gmail account (tt7199425@gmail.com) as I don't know how to authenticate the users email (possibly related to #37). However, it is successfully sending invitations from this gmail account.

Test:
1. Login as admin (admin:admin).
2. Create participants and a study.
3. View the study and click Send Invitation.
4. Participants now receive invitation emails.