### PR TITLE
Copy a study

### DIFF
--- a/src/main/webapp/app/entities/study/study-dialog.component.ts
+++ b/src/main/webapp/app/entities/study/study-dialog.component.ts
@@ -150,8 +150,13 @@ export class StudyPopupComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.routeSub = this.route.params.subscribe((params) => {
             if ( params['id'] ) {
-                this.studyPopupService
+                if (this.route.snapshot.data.copy) {
+                    this.studyPopupService
+                    .copy(StudyDialogComponent as Component, params['id'])
+                } else {
+                    this.studyPopupService
                     .open(StudyDialogComponent as Component, params['id']);
+                }
             } else {
                 this.studyPopupService
                     .open(StudyDialogComponent as Component);

--- a/src/main/webapp/app/entities/study/study-popup.service.ts
+++ b/src/main/webapp/app/entities/study/study-popup.service.ts
@@ -39,6 +39,20 @@ export class StudyPopupService {
         });
     }
 
+    // copy a study by fetching the original study and setting the id to null
+    copy(component: Component, id?: number | any): Promise<NgbModalRef> {
+        console.log("copy");
+        return new Promise<NgbModalRef>((resolve, reject) => {
+            setTimeout(() => {
+                this.studyService.find(id).subscribe(study => {
+                    study.id = null;
+                    this.ngbModalRef = this.studyModalRef(component, study);
+                    resolve(this.ngbModalRef);
+                });
+            });
+        });
+    }
+
     studyModalRef(component: Component, study: Study): NgbModalRef {
         const modalRef = this.modalService.open(component, { size: 'lg', backdrop: 'static'});
         modalRef.componentInstance.study = study;

--- a/src/main/webapp/app/entities/study/study.component.html
+++ b/src/main/webapp/app/entities/study/study.component.html
@@ -43,6 +43,13 @@
                       <span class="fa fa-pencil"></span>
                       <span class="hidden-md-down">Edit</span>
                   </button>
+                  <button type="submit" 
+                          [routerLink]="['/', { outlets: { popup: 'study/'+ study.id + '/copy'} }]" 
+                          replaceUrl="true" 
+                          class="btn btn-success btn-sm">
+                    <span class="fa fa-copy"></span>
+                    <span class="hidden-md-down">Copy</span>
+                  </button>
                   <button type="submit"
                           [routerLink]="['/', { outlets: { popup: 'study/'+ study.id + '/delete'} }]"
                           replaceUrl="true"

--- a/src/main/webapp/app/entities/study/study.route.ts
+++ b/src/main/webapp/app/entities/study/study.route.ts
@@ -51,6 +51,17 @@ export const studyPopupRoute: Routes = [
         outlet: 'popup'
     },
     {
+        path: "study/:id/copy",
+        component: StudyPopupComponent,
+        data: {
+            authorities: ["ROLE_USER"],
+            pageTitle: "Studies",
+            copy: true
+        },
+        canActivate: [UserRouteAccessService],
+        outlet: "popup"
+    },
+    {
         path: 'study/:id/delete',
         component: StudyDeletePopupComponent,
         data: {


### PR DESCRIPTION
Resolves #20 

![capture](https://user-images.githubusercontent.com/615341/37251879-f1095038-257c-11e8-9356-e1b6308e3f39.PNG)

Clicking the copy button will open up a New Study dialog with all the fields filled in from the original study.

Note: the `copy` function in the `StudyPopupService` shares code with the `open` function but I've made it separate to prevent merge conflicts for people using the `open` function with its existing signature.
