### PR TITLE
Providing a better password status alert to the user

### DIFF
--- a/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html
+++ b/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html
@@ -12,7 +12,7 @@
             </div>
 
             <div class="alert alert-success" *ngIf="success === 'OK'">
-                <p>Check your emails for details on how to reset your password.</p>
+                <p>Instructions for resetting your password have been sent to {{resetAccount.email}}</p>
             </div>
 
             <form *ngIf="!success" name="form" role="form" (ngSubmit)="requestReset()" #resetRequestForm="ngForm">


### PR DESCRIPTION
In reference to ticket #74 , a successful password reset status alert now contains the user's email.  
  
This quality of life change will improve the password reset alert to give a better indication of which email address the recovery email has been sent to. This matches industry UX best practices.
