### PR TITLE
Issue #8 - Adding Send option to main study page 

### DIFF
--- a/src/main/webapp/app/entities/study/study.component.html
+++ b/src/main/webapp/app/entities/study/study.component.html
@@ -57,6 +57,12 @@
                       <span class="fa fa-remove"></span>
                       <span class="hidden-md-down">Delete</span>
                   </button>
+                  <button type="submit"
+                  [routerLink]="['/', { outlets: { popup: 'study/'+ study.id + '/confirmSend'} }]"
+                  replaceUrl="true"
+                  class="btn btn-success btn-sm">
+                    <span class="fa fa-paper-plane"></span>&nbsp;<span> Send Invitation</span>
+                </button>
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
This issue has been completed and the new UI and code changes is ready for review. A new button has been added into the main study page for sending invitations. 

# Changes
A new button was added into the study component next to the other buttons. The styling was kept the same as the send invitation button on the individual studies page apart from resizing it for styling consistency with the other buttons on the main study page. The routing from issue #6 was also implemented in this button to enable the confirm invitation send pop-up modal on this page. 