### PR TITLE
#40 - Connecting GitHub API for Researchers to search for new participants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,13 @@
 
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.kohsuke/github-api -->
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>1.92</version>
+        </dependency>
+
         <dependency>
             <groupId>io.github.jhipster</groupId>
             <artifactId>jhipster</artifactId>

--- a/src/main/java/org/project36/qualopt/service/github/GitHubAPIRequest.java
+++ b/src/main/java/org/project36/qualopt/service/github/GitHubAPIRequest.java
@@ -1,0 +1,112 @@
+package org.project36.qualopt.service.github;
+
+import org.project36.qualopt.service.github.GitHubUserType;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * A GitHub API Request that contains the information entered from the front end GitHub API
+ * User Search Form. The Springboot framework automatically marshalls this object when the
+ * GitHubResource receives a HTTP Request
+ */
+public class GitHubAPIRequest implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int muleId;
+
+    private GitHubUserType userType;
+
+    private String keyword;
+
+    private String numberOfRepositories;
+
+    private String location;
+
+    private String joinedBeforeDate;
+
+    private String programmingLanguage;
+
+    private String numberOfFollowers;
+
+    private boolean requestedContributionCount;
+
+    private int maxNumberOfUserLookups;
+
+    public Integer getMuleId(){
+        return muleId;
+    }
+    
+    public GitHubUserType getUserType(){
+        return userType;
+    }
+
+    public String getKeyword(){
+        return keyword;
+    }
+
+    public String getNumberOfRepositories(){
+        return numberOfRepositories;
+    }
+    
+    public String getLocation(){
+        return location;
+    }
+    
+    public String getJoinedBeforeDate(){
+        return joinedBeforeDate;
+    }
+    
+    public String getProgrammingLanguage(){
+        return programmingLanguage;
+    }
+    
+    public String getNumberOfFollowers(){
+        return numberOfFollowers;
+    }
+
+    public boolean getRequestedContributionCount(){
+        return requestedContributionCount;
+    }
+
+    public int getMaxNumberOfUserLookups(){
+        return maxNumberOfUserLookups;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GitHubAPIRequest request = (GitHubAPIRequest) o;
+
+        //Using toString() as this will compare ALL other fields.
+        return !(request.toString().equals(o.toString()));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getMuleId());
+    }
+
+    @Override
+    public String toString() {
+        return "GitHubUserSearchAPIRequest{" +
+            "muleId='" + muleId + '\'' +
+            ", userType='" + userType + '\'' +
+            ", keyword='" + keyword + '\'' +
+            ", numberOfRepositories='" + numberOfRepositories + '\'' +
+            ", location='" + location + '\'' +
+            ", joinedBeforeDate='" + joinedBeforeDate + '\'' +
+            ", programmingLanguage='" + programmingLanguage + '\'' +
+            ", numberOfFollowers='" + numberOfFollowers + '\'' +
+            ", requestedContributionCount='" + requestedContributionCount + '\'' +
+            ", maxNumberOfUserLookups='" + maxNumberOfUserLookups + '\'' +
+            "}";
+    }
+}

--- a/src/main/java/org/project36/qualopt/service/github/GitHubUserType.java
+++ b/src/main/java/org/project36/qualopt/service/github/GitHubUserType.java
@@ -1,0 +1,8 @@
+package org.project36.qualopt.service.github;
+
+//** Simple Enum to maintain the UserType passed from the frontend */
+public enum GitHubUserType {
+    USER,
+    ORG,
+    NOPREFERENCE
+}

--- a/src/main/java/org/project36/qualopt/web/rest/GitHubResource.java
+++ b/src/main/java/org/project36/qualopt/web/rest/GitHubResource.java
@@ -1,0 +1,255 @@
+package org.project36.qualopt.web.rest;
+
+import com.codahale.metrics.annotation.Timed;
+import org.project36.qualopt.domain.Participant;
+import org.project36.qualopt.service.github.GitHubAPIRequest;
+import org.project36.qualopt.repository.ParticipantRepository;
+import org.project36.qualopt.web.rest.errors.GHRateLimitReachedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.kohsuke.github.*;
+import java.io.IOException;
+import java.lang.Integer;
+import java.net.URISyntaxException;
+import java.util.List;
+
+/**
+ * REST controller for managing Participant.
+ */
+@RestController
+@RequestMapping("/api")
+public class GitHubResource {
+
+    private final Logger log = LoggerFactory.getLogger(GitHubResource.class);
+
+    private final ParticipantRepository participantRepository;
+
+    public GitHubResource(ParticipantRepository participantRepository) {
+        this.participantRepository = participantRepository;
+    }
+     
+     /**
+     * POST /gitHubQuery : Create a new GitHub User Search and populate the Participant repository
+     *                       with representations of the results
+     *
+     * @param gitHubAPIRequest the infomration from the API form that the user submitted
+     * @return the Response with status 201 (Created) if the results were successfully added, or with status 400 (Bad Request) if an error occured, with different strings
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @PostMapping("/gitHubQuery")
+    @Timed
+    public ResponseEntity<String> createGitHubAPIUserSearch(@RequestBody GitHubAPIRequest gitHubAPIRequest) throws URISyntaxException {
+        log.debug("REST request to send GitHub API user search : {}", gitHubAPIRequest.toString());
+        try{
+            sendGitHubAPIUserSearch(gitHubAPIRequest);
+        }catch(IOException e){
+            log.debug("Unable To Connect to the GitHub API");
+            return ResponseEntity.badRequest()
+                .body("Error when contacting the GitHub API - " + e.getMessage());
+        }catch(GHException e) {
+            log.debug("Error sending GitHub API Request, but was able to connect");
+            return ResponseEntity.badRequest()
+                .body("Error when contacting the GitHub API - " + e.getMessage());
+        }catch(GHRateLimitReachedException e){
+            log.debug("Error contacting GitHub API - Reached API Rate Limit");
+            return ResponseEntity.badRequest()
+                .body("Error contacting GitHub API - Reached API Rate Limit");
+        }
+        log.debug("Succesfully completed GitHub API user searcgh, sending an OK HTTP Request");
+        return ResponseEntity.ok()
+            .body(gitHubAPIRequest.toString());
+    }
+
+    /**
+     * Helper method to connect to the GitHub API and subsequently send the user search request. Uses
+     * the kohsuke.github maven repository in order to provide an object model for the different GitHub
+     * resources. Please refer to http://github-api.kohsuke.org/apidocs/index.html for more information.
+     * 
+     * TODO: Add a timeout in this method/surrounding this method to make the call more robust in case of network failure
+     * TODO: Add ability to connect using logged in credentials to increase API calls per hour
+     * 
+     * @param gitHubAPIRequest the infomration from the API form that the user submitted
+     * @throws IOException if connection unable to be established
+     * @throws GHException if request was rejected by the API
+     * @throws GHRateLimitReachedException custom exception thrown if API call limit reached for this hour.
+     */
+    private void sendGitHubAPIUserSearch(GitHubAPIRequest gitHubAPIRequest) throws IOException, GHException, GHRateLimitReachedException {
+        GitHub github = GitHub.connectAnonymously();
+        log.debug("Connected to GitHub Anonymously");
+
+        int currentRateLimit = github.getRateLimit().remaining;
+        currentRateLimit = checkRateLimit(currentRateLimit);
+        log.debug("Rate Limit after connecting is underestimated at = " + currentRateLimit);
+
+        GHUserSearchBuilder search = github.searchUsers();
+        buildUserSearch(search, gitHubAPIRequest);
+     
+        // Code for allowing for modifiable pagination; change this if it starts to page the search 
+        // results for some reason.
+        // search.withPageSize(pageSize);
+
+        // Performs the actual API query and then checks the limit
+        PagedSearchIterable<GHUser> searchResults = search.list();
+        currentRateLimit = checkRateLimit(currentRateLimit);
+
+        String totalNumberResults = Integer.toString(searchResults.getTotalCount());
+        log.debug("Total Number of Users found for current request = " + totalNumberResults);
+
+        int userLimiter = 0;
+        int maxUserLookups = gitHubAPIRequest.getMaxNumberOfUserLookups(); // will break out of for loop if exceeded
+        for(GHUser currentUser : searchResults){
+            userLimiter++;
+            currentRateLimit = checkRateLimit(currentRateLimit);
+            if(userLimiter > maxUserLookups){
+                log.debug("Reached the specified max user lookup from the GitHub API Form - Exiting now");
+                break;
+            }
+            try{
+                // Take the GHUser and convert them to a Participant reprenesentation and store.
+                Participant convertedParticipant = convertToParticipant(currentUser, gitHubAPIRequest, currentRateLimit);
+                participantRepository.save(convertedParticipant);
+            }catch(IOException e){
+                log.debug("Unable to convert participant, skipping");
+            }
+        }
+    }
+
+     /**
+     * Helper method to keep track of the estimated rate limit. Uses and returns int instead of querying
+     * the API every time to check the rate limit (too many network calls).
+     * 
+     * @param currentRateLimit cached int value representing the allotted API calls remaining
+     * @throws GHRateLimitReachedException custom exception thrown if API call limit reached for this hour.
+     */
+    private int checkRateLimit(int currentRateLimit) throws GHRateLimitReachedException {
+        // Want to be conservative so even if the counter says that the rate limit isn't 0, we want
+        // to terminate early in order to avoid getting stuck waiting for a API request when out of allocated calls. 
+        if(currentRateLimit <= 5){
+            throw new GHRateLimitReachedException("Rate Limit nearly reached! Prematurely aborting the request");
+        }
+        return currentRateLimit--;
+    }
+
+    /**
+     * Helper method to add the correct information to the GHUserSearchBuilder object, which
+     * is responsible for maintaining the URL used to query GitHub.
+     * 
+     * @param search the GHUserSearchBuilder used to construct the query string
+     * @param gitHubAPIRequest the infomration from the API form that the user submitted
+     */
+    private void buildUserSearch(GHUserSearchBuilder search, GitHubAPIRequest gitHubAPIRequest) {
+        switch(gitHubAPIRequest.getUserType()){
+            case USER:
+                search.type("user");
+                break;
+            case ORG:
+                search.type("org");
+                break;
+            case NOPREFERENCE:
+                // Don't need to add anything to the search term
+                break;
+        }
+
+        if(gitHubAPIRequest.getKeyword() != null){
+            search.q(gitHubAPIRequest.getKeyword());
+        }
+
+        if(gitHubAPIRequest.getNumberOfRepositories() != null){
+            search.repos(gitHubAPIRequest.getNumberOfRepositories());
+        }
+
+        if(gitHubAPIRequest.getLocation() != null){
+            search.location(gitHubAPIRequest.getLocation());
+        }
+
+        if(gitHubAPIRequest.getJoinedBeforeDate() != null){
+            search.created(gitHubAPIRequest.getJoinedBeforeDate());
+        }
+
+        if(gitHubAPIRequest.getProgrammingLanguage() != null){
+            search.language(gitHubAPIRequest.getProgrammingLanguage());
+        }
+
+        if(gitHubAPIRequest.getNumberOfFollowers() != null){
+            search.followers(gitHubAPIRequest.getNumberOfFollowers());
+        }
+	}
+
+    /**
+     * Helper method to convert a GitHub user representation to a Participant.
+     * Encapsulates any changes to the Participant class - simply add extra function calls
+     * on the convertedParticipant object within this function
+     * 
+     * TODO: IMPROVE THE CONTRIBUTION COUNT CHECK - currently does far too many calls as a result of REST limitations 
+     *       solution = switch to GraphQL?
+     * TODO: Currently just setting fake email address for safety. To change this to produce participants with real emails:
+     *      convertedParticipant.email(ghUser.getEmail()) - but check the kohsuke.github javadocs for most up to date implementation.
+     * 
+     * @param ghUser the current user to build a particpat out of
+     * @param gitHubAPIRequest the infomration from the API form that the user submitted
+     * @param currentRateLimit cached int value representing the allotted API calls remaining
+     * @throws IOException if network problem occurs
+     */
+	private Participant convertToParticipant(GHUser ghUser, GitHubAPIRequest gitHubAPIRequest, int currentRateLimit) throws IOException {
+        Participant convertedParticipant = new Participant();
+
+        // Set all the basic fields possible
+        convertedParticipant
+            .email(ghUser.getLogin()+"@fake.email.co.nz")
+            .occupation(ghUser.getCompany())
+            .location(ghUser.getLocation())
+            .numberOfRepositories(ghUser.getPublicRepoCount());
+        
+        // Currently, will set the page size and do a single REST request to get a number of repositories
+        // and set the programming language to the first language its able to find.
+        PagedIterable<GHRepository> allRepos = ghUser.listRepositories();
+        int numberOfReposToCheck = 10; // Arbitrary number to check - defines the number of repos obtained per page! 
+        PagedIterator<GHRepository> repoIterator = allRepos.withPageSize(numberOfReposToCheck).iterator();
+        String firstProgrammingLanguageFound = null;
+        for(int i = 0; i < numberOfReposToCheck; i++){
+            if(firstProgrammingLanguageFound == null){
+                if(repoIterator.hasNext()){
+                    GHRepository checkRepo = repoIterator.next();
+                    firstProgrammingLanguageFound = checkRepo.getLanguage();
+                }
+            }else{
+                // the checkRepo variable also has #listLanguages() to get multiple languages if we wanted that
+                convertedParticipant.programmingLanguage(firstProgrammingLanguageFound);
+                break;
+            }
+        }
+        
+        // User must explicitly specify they want Contribution Count on form, else this is skipped.
+        if(gitHubAPIRequest.getRequestedContributionCount()){
+            log.debug("BEGINNING CONTRIBUTION COUNT - EXTREMELY NETWORK INTENSIVE!!!");
+            allRepos = ghUser.listRepositories(ghUser.getPublicRepoCount()); // Set page size to number of repos for reducing request count
+            int contributionCounter = 0;
+
+            // This is the area with unfortunate consequences - the REST API only exposes repositories, meaning
+            // you must iterate through each of the repos that a user has to get their total contribution count, 
+            // and you then must find them as a contributor in each repository. This is EXTREMELY inefficient -
+            // an unfortunate consequence of using a pure REST API architecture.
+            // TODO: Could submit a feature request/query to the maintainer of the GitHub API maven repoistory being used OR switch to GraphQL
+            for(GHRepository repo : allRepos){
+                // Check rate limit EACH time we try a new repo
+                currentRateLimit = checkRateLimit(currentRateLimit);
+
+                // Large page sizes (1000 contributors per page, but each contributor is very small) have been used, 
+                // to avoid having to page a single request for contributors over and over
+                PagedIterable<GHRepository.Contributor> contributors = repo.listContributors().withPageSize(1000);
+                List<GHRepository.Contributor> contributorsList = contributors.withPageSize(1000).asList();
+                int indexCheck = contributorsList.indexOf(ghUser); // Have to index in the contributor list
+                if(indexCheck >= 0){
+                    GHRepository.Contributor currentUserAsContributor = contributorsList.get(indexCheck); // Look up the same contributor here
+                    int userContributionsToCurrentRepo = currentUserAsContributor.getContributions();
+                    log.debug("Found this many contributions for this repo: "+userContributionsToCurrentRepo);
+                    contributionCounter += userContributionsToCurrentRepo;
+                }
+            }
+            convertedParticipant.numberOfContributions(contributionCounter);
+        }
+        return convertedParticipant;
+    }
+}

--- a/src/main/java/org/project36/qualopt/web/rest/errors/GHRateLimitReachedException.java
+++ b/src/main/java/org/project36/qualopt/web/rest/errors/GHRateLimitReachedException.java
@@ -1,0 +1,13 @@
+package org.project36.qualopt.web.rest.errors;
+
+/**
+ * Simple Exception to dicate when the Rate Limit has been exceeded
+ */
+public class GHRateLimitReachedException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public GHRateLimitReachedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/webapp/app/entities/participant/githubAPI/github-API-request.model.ts
+++ b/src/main/webapp/app/entities/participant/githubAPI/github-API-request.model.ts
@@ -1,0 +1,39 @@
+import { BaseEntity } from '../../../shared';
+
+/** Enum representing the type of user selected in the dropdown box
+ * in the Github User Search Form.
+ */
+export enum UserType {
+    USER,
+    ORG,
+    NOPREFERNCE
+}
+
+/** Simple object for maintaining the infomration that the user enters
+ * in the GitHub User Search Form.
+ *
+ * This class uses strings for numberOfRepositories and numberOfFollowers
+ * as they can be optionally prefixed with ">,>=,<,<=" - and are passed into
+ * the API request as a string as well.
+ *
+ * The requestedContributionCount boolean is there to alert users that searching
+ * up contribution counts can be very exhaustive (due to the REST nature of the current
+ * call to the GitHub API)
+ */
+export class GitHubAPIRequest implements BaseEntity {
+    constructor(
+        public id?: number,
+        public keyword?: string,
+        public userType?: UserType,
+        public numberOfRepositories?: string,
+        public location?: string,
+        public joinedBeforeDate?: string,
+        public programmingLanguage?: string,
+        public numberOfFollowers?: string,
+        public requestedContributionCount?: boolean,
+        public maxNumberOfUserLookups?: number
+    ) {
+        this.userType = UserType.NOPREFERNCE;
+        this.maxNumberOfUserLookups = 0;
+    }
+}

--- a/src/main/webapp/app/entities/participant/githubAPI/github-backend-call.service.ts
+++ b/src/main/webapp/app/entities/participant/githubAPI/github-backend-call.service.ts
@@ -1,0 +1,32 @@
+import { Component, Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
+import { GitHubAPIRequest } from './github-API-request.model';
+import { Http, Response, RequestOptions } from '@angular/http';
+
+/** Helper class to invoke the call to the back end resource handler (GitHubResource.java),
+ * putting the GitHubUserSearchAPIRequest (containing the users desired search terms) into
+ * the body of the HTTP Post request.
+ */
+@Injectable()
+export class GitHubBackendCall {
+    private resourceUrl = 'api/gitHubQuery';
+
+    constructor(private http: Http) {
+    }
+
+    /** Creates and posts the HTTP request to the backend resource */
+    create(gitHubAPIRequest: GitHubAPIRequest): Observable<string> {
+        const copy = this.convert(gitHubAPIRequest);
+        return this.http.post(this.resourceUrl, copy).map((res: Response) => {
+            return res.text();
+        });
+    }
+
+    /** Private helper method to return a copy of the infomration, to ensure a const copy
+     * is passed into the http.post() method
+     */
+    private convert(gitHubAPIRequest: GitHubAPIRequest): GitHubAPIRequest {
+        const copy: GitHubAPIRequest = Object.assign({}, gitHubAPIRequest);
+        return copy;
+    }
+}

--- a/src/main/webapp/app/entities/participant/githubAPI/participant-github-popup.service.ts
+++ b/src/main/webapp/app/entities/participant/githubAPI/participant-github-popup.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { Observable } from 'rxjs/Rx';
+import { GitHubAPIRequest } from './github-API-request.model';
+
+/** Manages spawning up the GitHub User Search form as a modal and
+ * sets the underlying model of the form to be a GitHubUserSearchAPIRequest object
+ */
+@Injectable()
+export class GitHubPopupService {
+    private ngbModalRef: NgbModalRef;
+
+    constructor(
+        private modalService: NgbModal,
+        private router: Router,
+    ) {
+        this.ngbModalRef = null;
+    }
+
+     /** Method used to open the Modal for the GitHub User Search form - returning
+     * a Promise containing the NgbModalRef.
+     */
+    open(component: Component, id?: number | any): Promise<NgbModalRef> {
+        return new Promise<NgbModalRef>((resolve, reject) => {
+            const isOpen = this.ngbModalRef !== null;
+            if (isOpen) {
+                resolve(this.ngbModalRef);
+            }
+
+            setTimeout(() => {
+                this.ngbModalRef = this.githubModalRef(component, new GitHubAPIRequest());
+                resolve(this.ngbModalRef);
+            }, 0);
+        });
+    }
+
+    /** Helper method to set the Modal - setting the model backing the form to
+     * be a GitHubUserSearchAPIRequest. This model will then be modified and editable
+     * by the user.
+     */
+    githubModalRef(component: Component, gitHubAPIRequest: GitHubAPIRequest): NgbModalRef {
+        const modalRef = this.modalService.open(component, { size: 'lg', backdrop: 'static'});
+        modalRef.componentInstance.gitHubAPIRequest = gitHubAPIRequest;
+        modalRef.result.then((result) => {
+            this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
+            this.ngbModalRef = null;
+        }, (reason) => {
+            this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
+            this.ngbModalRef = null;
+        });
+        return modalRef;
+    }
+}

--- a/src/main/webapp/app/entities/participant/githubAPI/participant-github-query-dialog.component.html
+++ b/src/main/webapp/app/entities/participant/githubAPI/participant-github-query-dialog.component.html
@@ -1,0 +1,91 @@
+<form name="editForm" role="form" novalidate (ngSubmit)="sendAPIRequest()" #editForm="ngForm">
+
+    <div class="modal-header">
+        <h4 class="modal-title" id="myGitHubQueryLabel">Create a new GitHub Query</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true" (click)="clear()">&times;</button>
+    </div>
+
+    <div class="modal-body">
+        <jhi-alert-error></jhi-alert-error>
+        <p>Please fill out the fields you'd like to query in the Github API</p>
+        <p>Any fields left blank will not be entered into the search query - so fill in the fields that you specifically want to search, as the GitHub API works by "AND"-ing these terms together.</p>
+        <div class="form-group">
+            <label class="form-control-label" for="field_userType">Type of User:</label>
+            <select class="form-control" name="userType" id="field_userType" [(ngModel)]="gitHubAPIRequest.userType">
+                <option selected value="NOPREFERENCE" selected="selected">User and Orginization (default)</option>
+                <option value="USER">User</option>
+                <option value="ORG">Organization</option>
+            </select>
+        </div>
+
+        <!-- Keyword -->
+        <div class="form-group">
+            <label class="form-control-label" for="field_keyword">Keyword Search:</label>
+            <input type="text" class="form-control" name="keyword" id="field_keyword" [(ngModel)]="gitHubAPIRequest.keyword">
+            <small class="form-text text-info">This will search the name, email and organization fields for a GitHub User</small>
+        </div>
+
+        <!-- Number of Repositories -->
+        <div class="form-group">
+            <label class="form-control-label" for="field_numberOfRepositories">Number Of Repositories:</label>
+            <input type="text" class="form-control" name="numberOfRepositories" id="field_numberOfRepositories" [(ngModel)]="gitHubAPIRequest.numberOfRepositories">
+            <small class="form-text text-info">Note: Optional prefix with >, >=, &lt;, &lt;=)</small>
+        </div>
+
+        <!-- Location -->
+        <div class="form-group">
+            <label class="form-control-label" for="field_location">Location:</label>
+            <input type="text" class="form-control" name="location" id="field_location" [(ngModel)]="gitHubAPIRequest.location">
+        </div>
+
+        <!-- Programming Languages -->
+        <div class="form-group">
+            <label class="form-control-label" for="field_programmingLanguage">Programming Language:</label>
+            <input type="text" class="form-control" name="programmingLanguage" id="field_programmingLanguage" max="10" [(ngModel)]="gitHubAPIRequest.programmingLanguage">
+        </div>
+
+        <!-- Joined Before -->
+        <div class="form-group">
+            <label class="form-control-label" for="field_joinedBefore">Date:</label>
+            <input type="text" class="form-control" name="joinedBefore" id="field_joinedBefore" [(ngModel)]="gitHubAPIRequest.joinedBeforeDate">
+            <small class="form-text text-info">Note: Date Format as YYYY-MM-DD, optional prefix with >, >=, &lt;, &lt;=)</small>
+        </div>
+
+        <!-- Number of Followers -->
+        <div class="form-group">
+            <label class="form-control-label" for="field_numberOfFollowers">Number Of Followers:</label>
+            <input type="text" class="form-control" name="numberOfFollowers" id="field_numberOfFollowers" [(ngModel)]="gitHubAPIRequest.numberOfFollowers">
+            <small class="form-text text-info">Note: Optional prefix with >, >=, &lt;, &lt;=)</small>
+        </div>
+
+        <!-- Requesting Contribution Count -->
+        <div class="form-group" style="white-space: nowrap; display:inline-block">
+            <label class="form-control-label" style="display:inline-block;" for="field_requestedContributionCount">Do you want to perform Contribution Counts on each User Lookup?</label>
+            <input type="checkbox" class="form-control" style="display: inline-block;" name="requestedContributionCount" id="field_requestedContributionCount" 
+                [(ngModel)]="gitHubAPIRequest.requestedContributionCount">
+            <small class="form-text text-danger" style="margin-bottom: 10px; margin-top: -5px;">WARNING: Very network intensive, only execute on searches with a small number of repositories per user!</small>
+        </div>
+
+        <!-- Max Number of User Lookups -->
+        <div class="form-group">
+            <label class="form-control-label" for="field_maxNumberOfUserLookups">Number of User Lookups:</label>
+            <input type="number" class="form-control" name="maxNumberOfUserLookups" id="field_maxNumberOfUserLookups" [(ngModel)]="gitHubAPIRequest.maxNumberOfUserLookups"
+                required min='0' max='10' pattern="^$|^([0-9]|[1][0])?" #rateInput2 = "ngModel">
+            <small class="form-text text-info">Note: Maximum value of 10</small>
+        </div>
+
+    </div>
+    </div>
+
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal" (click)="clear()">
+            <span class="fa fa-ban"></span>&nbsp;
+            <span>Cancel</span>
+        </button>
+        <button type="submit" [disabled]="editForm.form.invalid" class="btn btn-primary">
+            <span class="fa fa-arrow-right"></span>&nbsp;
+            <span>Send User Search to GitHub API</span>
+        </button>
+    </div>
+</form>

--- a/src/main/webapp/app/entities/participant/githubAPI/participant-github-query-dialog.component.ts
+++ b/src/main/webapp/app/entities/participant/githubAPI/participant-github-query-dialog.component.ts
@@ -1,0 +1,99 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Response, Http } from '@angular/http';
+
+import { Observable } from 'rxjs/Rx';
+import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { JhiEventManager, JhiAlertService } from 'ng-jhipster';
+import { GitHubPopupService } from './participant-github-popup.service';
+import { GitHubBackendCall } from './github-backend-call.service';
+import { GitHubAPIRequest, UserType } from './github-API-request.model';
+
+/** This class represents the component that controls the model and the
+ * API call to the backend to send a GitHub API request to search users.
+ * Note: The backend is responsible for the production of participants and the
+ * success/fail HTTP Responses.
+ */
+@Component({
+    selector: 'jhi-participant-github-query-dialog',
+    templateUrl: './participant-github-query-dialog.component.html'
+})
+export class GitHubQueryDialogComponent implements OnInit {
+    gitHubAPIRequest: GitHubAPIRequest
+
+    constructor(
+        public activeModal: NgbActiveModal,
+        private alertService: JhiAlertService,
+        private eventManager: JhiEventManager,
+        private gitHubQueryPopupService: GitHubPopupService,
+        private gitHubBackendCall: GitHubBackendCall
+    ) {
+    }
+
+    ngOnInit() {
+    }
+
+    clear() {
+        this.activeModal.dismiss('cancel');
+    }
+
+    /** Method called to submit the values the user entered into the GitHub User Search Form */
+    sendAPIRequest() {
+        console.log(this.gitHubAPIRequest);
+        this.subscribeToAPIResponse(
+            this.gitHubBackendCall.create(this.gitHubAPIRequest));
+
+        // TODO: Show some kind of status/loading indication instead of just dismissing modal
+        this.activeModal.dismiss(this.gitHubAPIRequest);
+    }
+
+    /** Subscribe method to handle result after the API call returns from the backend */
+    private subscribeToAPIResponse(result: Observable<string>) {
+        result.subscribe((res: string) =>
+            this.onAPIResponseSuccess(res), (res: Response) => this.onAPIResponseError(res));
+    }
+
+    /** Method to handle the resulting string passed back in the body of a success (OK) HTTP Response */
+    private onAPIResponseSuccess(result: string) {
+        this.eventManager.broadcast({ name: 'participantListModification', content: 'OK'});
+    }
+
+    /** Method to handle the resulting string passed back in the body of a fail (bad request) HTTP Response */
+    private onAPIResponseError(error) {
+        this.onError(error);
+    }
+
+    private onError(error) {
+        this.alertService.error(error.text(), null, null);
+    }
+}
+
+@Component({
+    selector: 'jhi-participant-github-query-popup',
+    template: ''
+})
+export class GitHubQueryPopupComponent implements OnInit, OnDestroy {
+
+    routeSub: any;
+
+    constructor(
+        private route: ActivatedRoute,
+        private githubQueryPopupService: GitHubPopupService
+    ) {}
+
+    ngOnInit() {
+        this.routeSub = this.route.params.subscribe((params) => {
+            if ( params['id'] ) {
+                this.githubQueryPopupService
+                    .open(GitHubQueryDialogComponent as Component, params['id']);
+            } else {
+                this.githubQueryPopupService
+                    .open(GitHubQueryDialogComponent as Component);
+            }
+        });
+    }
+
+    ngOnDestroy() {
+        this.routeSub.unsubscribe();
+    }
+}

--- a/src/main/webapp/app/entities/participant/participant.component.html
+++ b/src/main/webapp/app/entities/participant/participant.component.html
@@ -43,6 +43,14 @@
                     <input class="form-control" type="number" id="filter_numberOfRepositories" name="numberOfRepositories" [(ngModel)]="filter.numberOfRepositories">
                 </div>
             </form>
+            <h5>Find More Participants</h5>
+            <button class="btn btn-primary float-left jh-create-entity send-github-participant-query" [routerLink]="['/', { outlets: { popup: ['github-query'] } }]">
+                <span class="fa fa-arrow-right"></span>
+                <span >
+                    Send GitHub API Query
+                </span>
+            </button>
+
         </div>
         <div class="col-9">
             <div class="table-responsive" *ngIf="participants">

--- a/src/main/webapp/app/entities/participant/participant.module.ts
+++ b/src/main/webapp/app/entities/participant/participant.module.ts
@@ -15,10 +15,13 @@ import {
     participantPopupRoute,
 } from './';
 import { ParticipantPipe } from './participant.pipe';
+import { GitHubBackendCall } from './githubAPI/github-backend-call.service';
+import { GitHubQueryDialogComponent, GitHubQueryPopupComponent } from './githubAPI/participant-github-query-dialog.component';
+import { GitHubPopupService } from './githubAPI/participant-github-popup.service';
 
 const ENTITY_STATES = [
     ...participantRoute,
-    ...participantPopupRoute,
+    ...participantPopupRoute
 ];
 
 @NgModule({
@@ -33,7 +36,9 @@ const ENTITY_STATES = [
         ParticipantDeleteDialogComponent,
         ParticipantPopupComponent,
         ParticipantDeletePopupComponent,
-        ParticipantPipe
+        ParticipantPipe,
+        GitHubQueryDialogComponent,
+        GitHubQueryPopupComponent
     ],
     entryComponents: [
         ParticipantComponent,
@@ -41,10 +46,14 @@ const ENTITY_STATES = [
         ParticipantPopupComponent,
         ParticipantDeleteDialogComponent,
         ParticipantDeletePopupComponent,
+        GitHubQueryDialogComponent,
+        GitHubQueryPopupComponent
     ],
     providers: [
         ParticipantService,
         ParticipantPopupService,
+        GitHubPopupService,
+        GitHubBackendCall
     ],
     schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })

--- a/src/main/webapp/app/entities/participant/participant.route.ts
+++ b/src/main/webapp/app/entities/participant/participant.route.ts
@@ -8,6 +8,7 @@ import { ParticipantComponent } from './participant.component';
 import { ParticipantDetailComponent } from './participant-detail.component';
 import { ParticipantPopupComponent } from './participant-dialog.component';
 import { ParticipantDeletePopupComponent } from './participant-delete-dialog.component';
+import { GitHubQueryPopupComponent } from './githubAPI/participant-github-query-dialog.component';
 
 export const participantRoute: Routes = [
     {
@@ -56,6 +57,16 @@ export const participantPopupRoute: Routes = [
         data: {
             authorities: ['ROLE_ADMIN'],
             pageTitle: 'Participants'
+        },
+        canActivate: [UserRouteAccessService],
+        outlet: 'popup'
+    },
+    {
+        path: 'github-query',
+        component: GitHubQueryPopupComponent,
+        data: {
+            authorities: ['ROLE_ADMIN', 'ROLE_USER'],
+            pageTitle: 'GitHub User Search Query'
         },
         canActivate: [UserRouteAccessService],
         outlet: 'popup'

--- a/src/main/webapp/app/shared/shared.module.ts
+++ b/src/main/webapp/app/shared/shared.module.ts
@@ -37,7 +37,7 @@ import {
         AuthServerProvider,
         SocialService,
         UserService,
-        DatePipe
+        DatePipe,
     ],
     entryComponents: [JhiLoginModalComponent],
     exports: [


### PR DESCRIPTION
The preliminary connection of the GitHub API to obtain new Participants is ready to be reviewed/pulled in - because other issues depend on this change, I’d like to begin reviewing these changes sooner rather than later. While we perform a code review and get feedback on this, I’ll investigate the feasibility of adding tests for these changes (although these might be more suited to a separate PR). 

**Please refer to some of the notes I made on #40 for some background on the workflow for using this feature.** 

### Summary of Front End Changes
Added a Form to retrieve information from the Researcher to send a GitHub API request. This includes introducing a specific model to back the form, and some new services for sending an internal REST query to our backend server. All additional files have been placed within the \app\entities\participant\githubAPI folder, but some changes to the files in the Participants entity folder were required to introduce routing to the new modal dialogue displaying the form.

### Some Specifics of Front End Changes
- The GitHub user search form itself is controlled by the `GitHubQueryDialogComponent `object, which is responsible for sending the request to the java resource handler. It subscribes to the response to be able to reload the Participants that have been added, but some additional work could be done in this component to convey better processing information to the user. The component and template can be found in the participant-github-query-dialog.component.[ts/html]
- The `GitHubQueryPopupComponent`/`GitHubPopupService `are used to manage the process of instantiating the model underlying the form, and producing the “popup” nature of the form.
- GitHubAPIRequest object represents the backing model of the form, which translates to having a member variable for each of the form fields that are displayed. These are modified by using the ngModel attribute in the html template.
- GitHubBackendCall provides the service of copying the `GitHubAPIRequest `object, and producing the call to the java resource handler class (with the `GitHubAPIRequest `object as the body of the message)
- Changes made to the routing/module of the Participants entity folder (to route to the new form) and added a button on the page to open up the modal - thus had a few changes to the html document for the Participants page as well.

### Summary of Back End Changes
Because of the CORS issues I encountered making an external API request from the front end, I opted to make the GitHub API call from the backend to promote interoperability. This change includes introducing a new Resource Handler, and some extra objects for marshaling and controlling logic flow. I’ve also added a new Maven dependency to a GitHub API java package (`kohsuke.github`) to allow for an abstracted view of the API and provide a domain model in a sense.

### Some Specifics of Back End Changes
- The resource handler is the `GitHubResource `class, which has been annotated to receive internal requests through the resource URL - `api/gitHubQuery.` It currently only has one HTTP handler method for a POST, taking a `GitHubAPIRequest `from the body of the HTML message. It will perform the search with the parameters entered into the form, and will the construct Participants and add them to the database to be displayed. Please refer to the comments/annotations in this class for additional information about I/O and Todos.
- Note: as an interim solution, **a fake email containing the users' GitHub username has been added to the constructed participant** (instead of the actual obtained email from the search query), the occupation has been set to the “company” field of a user (no actual occupation information available), and the programming language set is the first primary language found for the users' repositories. **Retrieving contribution counts have been disabled by default (checkbox form), as this is extremely network intensive and will potentially max out an API call allocation quickly (limitations of REST API’s – could investigate GraphQL to optimize this)**. API calls limited to 60/hour currently, but can be increased to 5000 if login with an authentication key.
- `GitHubAPIRequest`/`GitHubUserType `are just backend mappings for information sent from the front end. These have automatic marshaling despite not having any annotations.

Although I’ve added some preliminary precautions to failures, this is quite a large change so I’m sure others will find bugs – let me know if you find some or have any general queries!
