### PR TITLE
#12 - Add warning that there are unsaved changes in the edit study form

### DIFF
--- a/src/main/webapp/app/entities/study/study-dialog.component.ts
+++ b/src/main/webapp/app/entities/study/study-dialog.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Response } from '@angular/http';
+import { NgForm } from '@angular/forms';
 
 import { Observable } from 'rxjs/Rx';
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
@@ -25,6 +26,8 @@ export class StudyDialogComponent implements OnInit {
     users: User[];
 
     participants: Participant[];
+
+    @ViewChild('editForm') editForm: NgForm;
 
     constructor(
         public activeModal: NgbActiveModal,
@@ -66,8 +69,36 @@ export class StudyDialogComponent implements OnInit {
         }
     }
 
+    /*
+    * This method is called when the user tries to cancel out of the study form.
+    * If the user has unsaved changes there are ask whether they want to save the
+    * to the save the changes before exiting.
+    */
     clear() {
-        this.activeModal.dismiss('cancel');
+        if (this.hasUnsavedChanges()) {
+            this.activeModal.dismiss('cancel');
+        } else {
+            if (confirm('Changes you made have not been saved! Would you like the discard the changes?')) {
+                this.activeModal.dismiss('cancel');
+            }
+        }
+
+    }
+
+    /*
+    * This method listens for events such as the window being closed or refreshed.
+    * If the user has unsaved changes a message is displayed warning the user of
+    * the unsaved changes.
+    */
+    @HostListener('window:beforeunload', ['$event'])
+    unloadNotification($event: any) {
+        if (!this.hasUnsavedChanges()) {
+            $event.returnValue = true;
+        }
+    }
+
+    private hasUnsavedChanges(): boolean {
+      return this.editForm.submitted || !this.editForm.dirty;
     }
 
     save() {

--- a/src/main/webapp/app/entities/study/study-dialog.component.ts
+++ b/src/main/webapp/app/entities/study/study-dialog.component.ts
@@ -82,7 +82,6 @@ export class StudyDialogComponent implements OnInit {
                 this.activeModal.dismiss('cancel');
             }
         }
-
     }
 
     /*


### PR DESCRIPTION
This pull request (fixes issue #14) makes the study edit/create forms more user-friendly and more error-tolerant. When the user has unsaved changes while they are editing/creating a study, they are warned of these unsaved changes when they try to navigate away from the form. They will receive the warning when they: 
* cancel out of the form 
* when they try to close the window
* when they try to reload the page.  

This addition prevents the user from inadvertently exiting out of the form and losing their work.