### PR TITLE
Fixing typos on the about page

### DIFF
--- a/src/main/webapp/app/entities/about/about.component.html
+++ b/src/main/webapp/app/entities/about/about.component.html
@@ -3,20 +3,11 @@
         <span class="hipster img-fluid img-rounded"></span>
     </div>
     <div class="col-md-9">
-        <button class="btn btn-primary float-right jh-create-entity create-participant" routerLink="../study">
-            <span class="fa fa-arrow-right"></span>
-            <span >
-            Go To Studies
-            </span>
-        </button>
+ 
         <h1 class="display-4">QualOpt</h1>
         <p class="lead">A Web Application to Support Qualitative Research</p>
 
-        <div [ngSwitch]="isAuthenticated()">
-            <div class="alert alert-success" *ngSwitchCase="true">
-                <span *ngIf="account"
-                   > You are logged in as user "{{account.login}}". </span>
-            </div>
+       
 
 
         <p>

--- a/src/main/webapp/app/entities/about/about.component.html
+++ b/src/main/webapp/app/entities/about/about.component.html
@@ -20,7 +20,7 @@
 
 
         <p>
-            QualOpt is a platform for software engineering researchers to manage survey invitations for their qualitative research studies, and find participants to send them to via GitHub.
+            QualOpt is a platform for software engineering researchers to manage survey invitations for their qualitative research studies and find participants to send them to via GitHub.
             The goal of this is to address the issue of GitHub users receiving too many unsolicited survey invitations via the GHTorrent project.
             We do this by providing a centralized location for researchers to find GitHub users, and for GitHub users to manage who can find them.
             <!-- TODO: More about QualOpt here -->
@@ -33,15 +33,15 @@
                     Researchers can use this application to send out survey invitations in moderation.<br/>
                     You can create a study on the application, with details of your survey and draft the email to be sent to your participants.<br/>
                     Additionally, you can filter the participants who will receive the survey invitations using information from GitHub.<br/>
-                    This is great if you want easy contact to a tailored set of willing participants for your surveys.
+                    This is great if you want easy contact with a tailored set of willing participants for your surveys.
                     <!-- TODO: More researcher info here -->
                 </p>
             </div>
             <div class="col-6">
                 <h2>For GitHub Users</h2>
                 <p>
-                    GitHub users will be able to use this app to moderate the number of survey invitations they recieve.<br/>
-                    You will also have the benefit of being able to customise the types of surveys they recieve invitations for.<br/>
+                    GitHub users will be able to use this app to moderate the number of survey invitations they receive.<br/>
+                    You will also have the benefit of being able to customize the types of surveys they receive invitations for.<br/>
                     We care about your privacy, so you're only giving out your email address to those who you want to see it.
                     <!-- TODO: More participant info here -->
                 </p>
@@ -50,8 +50,8 @@
             <div class="col-6">
                 <h2>About the project</h2>
                 <p>
-                    QaulOpt was originally worked on by Fraser Lewis-Smith and Dinal Wanniarachchi. Qual opt was then 
-                    further developed by the students of SoftEng 701. QualOpt was developed under the supervision of Dr Kelly Blincoe.
+                    QaulOpt was originally worked on by Fraser Lewis-Smith and Dinal Wanniarachchi. QualOpt was then 
+                    further developed by the students of SoftEng 701. QualOpt was developed under the supervision of Dr. Kelly Blincoe.
                     <!-- TODO: More participant info here -->
                 </p>
             </div>


### PR DESCRIPTION
# Overview

- Fixed all typing and punctuation errors in the about page referencing issue #29

## Testing
- Same as that conducted in PR #56

- Advise on any changes