### PR TITLE
Limit quantitative participant filtering

### DIFF
--- a/src/main/webapp/app/entities/participant/participant.component.html
+++ b/src/main/webapp/app/entities/participant/participant.component.html
@@ -36,11 +36,11 @@
                 </div>
                 <div class="form-group">
                     <label for="filter_numberOfContributions">Minimum number of contributions</label>
-                    <input class="form-control" type="number" id="filter_numberOfContributions" name="numberOfContributions" [(ngModel)]="filter.numberOfContributions">
+                    <input class="form-control" type="number" id="filter_numberOfContributions" name="numberOfContributions" min=0 max={{getMaxContributions()}} [(ngModel)]="filter.numberOfContributions">
                 </div>
                 <div class="form-group">
                     <label for="filter_numberOfRepositories">Minimum number of repositories</label>
-                    <input class="form-control" type="number" id="filter_numberOfRepositories" name="numberOfRepositories" [(ngModel)]="filter.numberOfRepositories">
+                    <input class="form-control" type="number" id="filter_numberOfRepositories" name="numberOfRepositories" min=0 max={{getMaxRepositories()}} [(ngModel)]="filter.numberOfRepositories">
                 </div>
             </form>
             <h5>Find More Participants</h5>

--- a/src/main/webapp/app/entities/participant/participant.component.ts
+++ b/src/main/webapp/app/entities/participant/participant.component.ts
@@ -43,6 +43,32 @@ export class ParticipantComponent implements OnInit, OnDestroy {
         this.reverse = true;
     }
 
+    /**
+     * This function returns the highest number of Repositories that any user has for limiting values in the
+     * participant filtering system.
+     * */
+    getMaxRepositories(){
+        return this.getMax(this.participants.map(p => p.numberOfRepositories));
+    }
+
+    /**
+     * This function returns the highest number of contributions that any user has for limiting values in the
+     * participant filtering system.
+     * */
+    getMaxContributions(){
+        return this.getMax(this.participants.map(p => p.numberOfContributions));
+    }
+
+    getMax(array: number[] ){
+        let  highestFound = 0;
+        for (let value of array){
+            if(value > highestFound){
+                highestFound = value;
+            }
+        }
+        return highestFound
+    }
+
     loadAll() {
         this.participantService.query({
             page: this.page,


### PR DESCRIPTION
This fixes issue #19 by constricting the user to the limits of the participant data rather than giving them infinite range.

Note: This issue is related to #41 as more filters may be added. But it is assumed when ticket 41 is solved it will be solved with the correct limits implemented.

Also the filtering logic may need to be ported to the setup study functionality, #34 is dependent on this ticket.

@wilmol @Karim-C