### PR TITLE
Use environment variables for Facebook secrets

### DIFF
--- a/src/main/java/org/project36/qualopt/config/social/SocialConfiguration.java
+++ b/src/main/java/org/project36/qualopt/config/social/SocialConfiguration.java
@@ -97,8 +97,8 @@ public class SocialConfiguration implements SocialConfigurer {
         }
 
         // Facebook configuration
-        String facebookClientId = environment.getProperty("spring.social.facebook.client-id");
-        String facebookClientSecret = environment.getProperty("spring.social.facebook.client-secret");
+        String facebookClientId = System.getenv("FACEBOOK_CLIENT_ID");
+        String facebookClientSecret = System.getenv("FACEBOOK_CLIENT_SECRET");
         if (facebookClientId != null && facebookClientSecret != null) {
             log.debug("Configuring FacebookConnectionFactory");
             connectionFactoryConfigurer.addConnectionFactory(
@@ -108,7 +108,7 @@ public class SocialConfiguration implements SocialConfigurer {
                 )
             );
         } else {
-            log.error("Cannot configure FacebookConnectionFactory id or secret null");
+            log.error("Cannot configure FacebookConnectionFactory id or secrets are null. Make sure that environment variables FACEBOOK_CLIENT_ID and FACEBOOK_CLIENT_SECRET are set.");
         }
 
         // Twitter configuration

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -52,10 +52,6 @@ spring:
             client-id: 409706338424-gpgeh591k6jku12eu0o31abscosngoal.apps.googleusercontent.com
             client-secret: 4mXwrXbgZ9qKM7EQyrwLaXKP
 
-        # see https://developers.facebook.com/docs/facebook-login/v2.2
-        facebook:
-            client-id: 1703434426389778
-            client-secret: 12a4ba62e573d9b78b4636d4dd3a497d
 
         # jhipster-needle-add-social-configuration
 


### PR DESCRIPTION
Addresses the secret keys issue for #22 

@st970703 @crat019 I propose simply replacing the getter for the keys with a `System.getenv` call. This would mean providing secrets as environment variables on the application host. If you think this is fine, I can also remove the old `environment` code.

Also we should probably add an option for setting these variables in the bash script as mentioned by @TheGuardianWolf 