### PR TITLE
Completed issue #99 and fixing typo on about page

### DIFF
--- a/src/main/webapp/app/entities/about/about.component.html
+++ b/src/main/webapp/app/entities/about/about.component.html
@@ -41,7 +41,7 @@
             <div class="col-6">
                 <h2>About the project</h2>
                 <p>
-                    QaulOpt was originally worked on by Fraser Lewis-Smith and Dinal Wanniarachchi. QualOpt was then 
+                    QualOpt was originally worked on by Fraser Lewis-Smith and Dinal Wanniarachchi. QualOpt was then 
                     further developed by the students of SoftEng 701. QualOpt was developed under the supervision of Dr. Kelly Blincoe.
                     <!-- TODO: More participant info here -->
                 </p>

--- a/src/main/webapp/app/entities/study/study.component.html
+++ b/src/main/webapp/app/entities/study/study.component.html
@@ -48,7 +48,7 @@
                   <button type="submit" 
                           [routerLink]="['/', { outlets: { popup: 'study/'+ study.id + '/copy'} }]" 
                           replaceUrl="true" 
-                          class="btn btn-success btn-sm">
+                          class="btn btn-warning btn-sm">
                     <span class="fa fa-copy"></span>
                     <span class="hidden-md-down">Copy</span>
                   </button>


### PR DESCRIPTION
Issue 99 was completed and also a small error for issue #29 was fixed. The colour of the copy button was changed and the code and UI change is ready to be reviewed. 

# Changes
On the main studies page, the copy button bootstrap button styling was changed from btn-success, to btn-warning. Even though the copy button is not a button that needs a warning, the UI still looks good and is not confusing. 

![iss99](https://user-images.githubusercontent.com/22784547/37804846-49ff5544-2e9b-11e8-862a-b40b81138f2d.png)

A string that read 'QaulOpt' was changed to 'QualOpt' on the about page as well. 
