### PR TITLE
Displaying of bounced emails #36.

### DIFF
--- a/.jhipster/Study.json
+++ b/.jhipster/Study.json
@@ -49,6 +49,10 @@
         {
             "fieldName": "status",
             "fieldType": "String"
+        },
+        {
+            "fieldName": "bouncedMail",
+            "fieldType": "String"
         }
     ],
     "changelogDate": "20170806142424",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "reflect-metadata": "0.1.10",
     "rxjs": "5.4.2",
     "swagger-ui": "2.2.10",
+    "sweetalert": "^2.1.0",
     "tether": "1.4.0",
     "zone.js": "0.8.13"
   },

--- a/qualopt.jh
+++ b/qualopt.jh
@@ -3,6 +3,7 @@ entity Study {
 	description TextBlob,
 	incentive TextBlob,
 	status String,
+	bouncedMail String,
 	emailSubject String required,
     emailBody TextBlob
 }

--- a/src/main/java/org/project36/qualopt/domain/Document.java
+++ b/src/main/java/org/project36/qualopt/domain/Document.java
@@ -24,6 +24,7 @@ public class Document implements Serializable {
     private String filename;
 
     @NotNull
+    @Lob
     @Column(name = "file_image")
     private String fileimage;
 

--- a/src/main/java/org/project36/qualopt/domain/Study.java
+++ b/src/main/java/org/project36/qualopt/domain/Study.java
@@ -55,6 +55,9 @@ public class Study implements Serializable {
     @ManyToOne
     private User user;
 
+    @Column(name = "bounced_mail")
+    private String bouncedMail;
+
     @ManyToMany
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JoinTable(name = "study_participant",
@@ -226,6 +229,14 @@ public class Study implements Serializable {
         this.documents = documents;
     }
 
+    public String getBouncedMail() {
+        return bouncedMail;
+    }
+
+    public void setBouncedMail(String bouncedMail) {
+        this.bouncedMail = bouncedMail;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -254,9 +265,9 @@ public class Study implements Serializable {
             ", description='" + getDescription() + "'" +
             ", incentive='" + getIncentive() + "'" +
             ", status='" + getStatus() + "'" +
-            ", faq='" + getFaq() + "'" +
             ", emailSubject='" + getEmailSubject() + "'" +
             ", emailBody='" + getEmailBody() + "'" +
+            ", bouncedMail='" + getBouncedMail() + "'" +
             "}";
     }
 }

--- a/src/main/java/org/project36/qualopt/repository/StudyRepository.java
+++ b/src/main/java/org/project36/qualopt/repository/StudyRepository.java
@@ -20,7 +20,7 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
     @Query("select study from Study study where study.user.login = ?#{principal.username}")
     Page<Study> findByUserIsCurrentUser(Pageable pageable);
 
-    @Query("select distinct study from Study study left join fetch study.participants")
+    @Query("select distinct study from Study study left join fetch study.participants left join fetch study.documents")
     List<Study> findAllWithEagerRelationships();
 
     @Query("select study from Study study left join fetch study.participants left join fetch study.documents where study.id =:id")

--- a/src/main/java/org/project36/qualopt/web/rest/StudyResource.java
+++ b/src/main/java/org/project36/qualopt/web/rest/StudyResource.java
@@ -142,7 +142,7 @@ public class StudyResource {
         if(study==null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
-        
+
         StudyInfoDTO studyInfo = new StudyInfoDTO(study);
         return new ResponseEntity<>(studyInfo, HttpStatus.OK);
     }

--- a/src/main/resources/.h2.server.properties
+++ b/src/main/resources/.h2.server.properties
@@ -1,5 +1,5 @@
 #H2 Server Properties
-#Mon Aug 21 02:24:58 NZST 2017
+#Fri Mar 23 21:15:48 NZDT 2018
 0=JHipster H2 (Memory)|org.h2.Driver|jdbc\:h2\:mem\:qualopt|QualOpt
 webAllowOthers=true
 webPort=8082

--- a/src/main/resources/config/liquibase/changelog/20170806142424_added_entity_Study.xml
+++ b/src/main/resources/config/liquibase/changelog/20170806142424_added_entity_Study.xml
@@ -38,6 +38,10 @@
                 <constraints nullable="false" />
             </column>
 
+            <column name="bounced_mail" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
             <column name="email_subject" type="varchar(255)">
                 <constraints nullable="false" />
             </column>

--- a/src/main/resources/config/liquibase/changelog/20180314100212_added_entity_Document.xml
+++ b/src/main/resources/config/liquibase/changelog/20180314100212_added_entity_Document.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-    
+
     <property name="now" value="now()" dbms="h2"/>
 
     <property name="now" value="now()" dbms="mysql"/>
@@ -16,7 +16,7 @@
         Added the columns for entity Study.
     -->
     <changeSet id="20180314100212-1" author="jhipster">
-        
+
         <createTable tableName="document">
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>
@@ -31,6 +31,6 @@
                                  constraintName="fk_study_document"
                                  referencedColumnNames="id"
                                  referencedTableName="study"/>
-        
+
     </changeSet>
 </databaseChangeLog>

--- a/src/main/webapp/app/entities/study/study-confirm-invitation.component.ts
+++ b/src/main/webapp/app/entities/study/study-confirm-invitation.component.ts
@@ -7,6 +7,12 @@ import { Study } from './study.model';
 import { StudyPopupService } from './study-popup.service';
 import { StudyService } from './study.service';
 
+import * as _swal from 'sweetalert';
+import { SweetAlert } from 'sweetalert/typings/core';
+import {StudyDetailComponent} from "./study-detail.component";
+import {JhiEventManager} from "ng-jhipster";
+const swal: SweetAlert = _swal as any;
+
 @Component({
     selector: 'jhi-study-confirm-dialog',
     templateUrl: './study-confirm-invitation.component.html'
@@ -17,6 +23,7 @@ export class StudyConfirmDialogComponent {
 
     constructor(
         private studyService: StudyService,
+        private eventManager: JhiEventManager,
         public activeModal: NgbActiveModal) {
     }
 
@@ -26,8 +33,35 @@ export class StudyConfirmDialogComponent {
 
     confirmSend() {
         console.log('Sending invitation email ...');
-        this.studyService.send(this.study).subscribe(res => console.log(`Bounced: ${res}`));
+        this.studyService.send(this.study).subscribe(bouncedMail => {
+            console.log(`Bounced: ${bouncedMail}`);
+            this.study.bouncedMail = bouncedMail.join(', ');
+            this.studyService.update(this.study).subscribe(() =>
+                this.eventManager.broadcast({ name: 'studyListModification', content: 'OK' }));
+            if (bouncedMail.length > 0){
+                this.showBouncedMailAlert(bouncedMail);
+            }
+        });
         this.activeModal.dismiss('sent');
+    }
+
+    private showBouncedMailAlert(bouncedMail: String[]){
+        let studyName = this.study.name;
+        let studyUrl = location.origin + "/#/study/" + this.study.id;
+        let formattedMail = bouncedMail.join('\n');
+        swal({
+            title: `Failed to send invitations for study: ${studyName}`,
+            text: `The following email addresses bounced:\n ${formattedMail}`,
+            icon: 'error',
+            closeOnClickOutside: false,
+            buttons: {
+                confirm: { text: `View ${studyName}` }
+            }
+        }).then(viewStudy => {
+            if (viewStudy){
+                location.href = studyUrl;
+            }
+        });
     }
 }
 

--- a/src/main/webapp/app/entities/study/study-detail.component.html
+++ b/src/main/webapp/app/entities/study/study-detail.component.html
@@ -27,16 +27,18 @@
         <dd>
             <span>{{study.faq}}</span>
         </dd>
-        <dt><span>FAQ</span></dt>
-        <dd>
-            <span>{{study.faq}}</span>
-        </dd>
         <dt><span>Participants</span></dt>
         <dd>
             <span *ngFor="let participant of study.participants; let last = last">
                 <a [routerLink]="['/participant', participant?.id ]">{{participant.email}}</a>{{last ? '' : ', '}}
             </span>
         </dd>
+        <div *ngIf="study.bouncedMail">
+        <dt><span>Bounced Participant Email Addresses</span></dt>
+        <dd>
+            <span>{{study.bouncedMail}}</span>
+        </dd>
+        </div>
     </dl>
 
     <button type="submit"

--- a/src/main/webapp/app/entities/study/study-detail.component.ts
+++ b/src/main/webapp/app/entities/study/study-detail.component.ts
@@ -13,9 +13,9 @@ import { StudyService } from './study.service';
 export class StudyDetailComponent implements OnInit, OnDestroy {
 
     study: Study;
+    status = Status;
     private subscription: Subscription;
     private eventSubscriber: Subscription;
-    status = Status;
 
     constructor(
         private eventManager: JhiEventManager,
@@ -47,16 +47,22 @@ export class StudyDetailComponent implements OnInit, OnDestroy {
     }
 
     previousState() {
-        window.history.back();
+        history.back();
     }
+
     // Changes the status of the study to active.
     beginStudy() {
         this.study.status = Status.ACTIVE;
-        this.studyService.update(this.study).subscribe();
+        this.updateStudy();
     }
+
     // Changes the status of the study to Completed.
     closeStudy() {
         this.study.status = Status.COMPLETED;
+        this.updateStudy();
+    }
+
+    updateStudy(){
         this.studyService.update(this.study).subscribe();
     }
 

--- a/src/main/webapp/app/entities/study/study.model.ts
+++ b/src/main/webapp/app/entities/study/study.model.ts
@@ -8,6 +8,7 @@ export class Study implements BaseEntity {
         public description?: any,
         public incentive?: any,
         public status?: Status,
+        public bouncedMail?: string,
         public emailSubject?: string,
         public emailBody?: any,
         public faq?: string,


### PR DESCRIPTION
Solution to #36.
This PR builds on #114 and contains the front-end changes.
I used a new package (sweetalert), 
please run `npm install` and maybe `npm install --save sweetalert`.

**Changes:**
- Added alert system that indicates when email addresses have bounced. The alert works asynchronously; it comes up when the service processes the bounced mail so the user can be browsing another page and receive the alert. Hopefully this is helpful for #26. The alert contains a link to view the study.
- Changed study entity to include bounced mail and save bounced email addresses to database.
- Change study detail component to show bounced email addresses. This only shows when there are bounced email addresses. This only updates after sending an invitation.

**Screenshot:**
Alert:
![screenshot from 2018-03-23 22-44-44](https://user-images.githubusercontent.com/18110897/37822810-74ec76be-2eec-11e8-9f82-7230f9115ccd.png)

New study detail component field:
![screenshot from 2018-03-23 22-45-05](https://user-images.githubusercontent.com/18110897/37822815-79d2db00-2eec-11e8-940b-d72b9f8a250d.png)

**Test:**
1. Login as admin (admin:admin).
2. Create some participants (some with invalid emails e.g. invalid123123123123123123@gmail.com).
(invalid address will throw an exception; this is another issue.)
3. Create a study and add the participants.
4. Send the study.
5. Wait for it to be sent.
6. The alert should come up (whether you stayed viewing the study or went to another page).
7. Viewing the study should show the bounced participant email address field.
8. Editing out the bad participants and resending the invitation should remove the bounced participant email address field from the study view. (Make sure you include at least one good email address.)

**Limitations:**
- The initial spec of #36 said to display success or failure. I only indicate failure because I think having async alerts for all sent invitations would be annoying to the user; especially when #26 is implemented and the user is likely busy doing something else.
- I noticed Gmail sub delivery system is sometimes slow so not all bounced email is retrieved. This could be fixed by having a dedicated service continuously checking the inbox and using a listener. However, this rarely happens and I feel its too much effort for a medium issue.
- Currently the database is recording bounced mail in the Study entity. It probably should be in the participant entity as if a participants email bounced for once study it probably will for other studies. Could then have a permanent alert when viewing the participant saying their email is bad.