### PR TITLE
Fix error with fileimage column

### DIFF
--- a/src/main/java/org/project36/qualopt/domain/Document.java
+++ b/src/main/java/org/project36/qualopt/domain/Document.java
@@ -24,6 +24,7 @@ public class Document implements Serializable {
     private String filename;
 
     @NotNull
+    @Lob
     @Column(name = "file_image")
     private String fileimage;
 


### PR DESCRIPTION
Apologies, there was an error with my pull request #93 as file image column was defined as clob in the database configuration file but didn't have the appropriate annotation in the document class. Thanks @dylHall for identifying the issue and helping out.