### PR TITLE
Google sign in uses environment for API keys

### DIFF
--- a/src/main/java/org/project36/qualopt/config/social/SocialConfiguration.java
+++ b/src/main/java/org/project36/qualopt/config/social/SocialConfiguration.java
@@ -79,8 +79,8 @@ public class SocialConfiguration implements SocialConfigurer {
     @Override
     public void addConnectionFactories(ConnectionFactoryConfigurer connectionFactoryConfigurer, Environment environment) {
         // Google configuration
-        String googleClientId = environment.getProperty("spring.social.google.client-id");
-        String googleClientSecret = environment.getProperty("spring.social.google.client-secret");
+        String googleClientId = System.getenv("GOOGLE_CLIENT_ID");
+        String googleClientSecret = System.getenv("GOOGLE_CLIENT_SECRET");
         if (googleClientId != null && googleClientSecret != null) {
             log.debug("Configuring GoogleConnectionFactory");
             connectionFactoryConfigurer.addConnectionFactory(
@@ -90,7 +90,8 @@ public class SocialConfiguration implements SocialConfigurer {
                 )
             );
         } else {
-            log.error("Cannot configure GoogleConnectionFactory id or secret null");
+            log.error("Cannot configure GoogleConnectionFactory id or secret is null. " +
+                "Make sure that environment variables GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are set.");
         }
 
         // Facebook configuration
@@ -105,7 +106,8 @@ public class SocialConfiguration implements SocialConfigurer {
                 )
             );
         } else {
-            log.error("Cannot configure FacebookConnectionFactory id or secrets are null. Make sure that environment variables FACEBOOK_CLIENT_ID and FACEBOOK_CLIENT_SECRET are set.");
+            log.error("Cannot configure FacebookConnectionFactory id or secrets are null. " +
+                "Make sure that environment variables FACEBOOK_CLIENT_ID and FACEBOOK_CLIENT_SECRET are set.");
         }
 
         // Twitter configuration

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -46,15 +46,8 @@ spring:
         favicon:
             enabled: false
     thymeleaf:
-        mode: HTML
-    social:
-        # Google API Keys created under the email: wmol664@aucklanduni.ac.nz and product name: QualOpt
-        # see https://developers.google.com/+/web/signin/server-side-flow#step_1_create_a_client_id_and_client_secret
-        google:
-            client-id: 409706338424-gpgeh591k6jku12eu0o31abscosngoal.apps.googleusercontent.com
-            client-secret: 4mXwrXbgZ9qKM7EQyrwLaXKP
-
-
+        mode: XHTML
+#    social: # Set social API keys in environment. see SocialConfiguration.java
         # jhipster-needle-add-social-configuration
 
 # security:

--- a/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
+++ b/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
@@ -1,18 +1,5 @@
 package org.project36.qualopt.web.rest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.List;
-
-import javax.persistence.EntityManager;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +21,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
  * Test class for the StudyResource REST controller.


### PR DESCRIPTION
Solution to #23 follow up PR to #64. 

**Change:** get Google client and secret from environment rather than expose them in this public repository. The keys would then be set at deployment e.g. in Heroku or similar. Need #105 to really test this.

