### PR TITLE
#40 - Adding unit tests for GitHubResource REST controller and refactoring for Testability

### DIFF
--- a/src/main/java/org/project36/qualopt/service/github/GitHubAPIRequest.java
+++ b/src/main/java/org/project36/qualopt/service/github/GitHubAPIRequest.java
@@ -1,5 +1,6 @@
 package org.project36.qualopt.service.github;
 
+import org.hibernate.usertype.UserType;
 import org.project36.qualopt.service.github.GitHubUserType;
 
 import java.io.Serializable;
@@ -38,40 +39,125 @@ public class GitHubAPIRequest implements Serializable {
         return muleId;
     }
     
+    public void setMuleId(int id){
+        this.muleId = id;
+    }
+
     public GitHubUserType getUserType(){
         return userType;
+    }
+
+    public GitHubAPIRequest userType(GitHubUserType userType){
+        this.userType = userType;
+        return this;
+    }
+
+    public void setUserType(GitHubUserType userType){
+        this.userType = userType;
     }
 
     public String getKeyword(){
         return keyword;
     }
 
+    public GitHubAPIRequest keyword(String keyword){
+        this.keyword = keyword;
+        return this;
+    }
+
+    public void setKeyword(String keyword){
+        this.keyword = keyword;
+    }
+
     public String getNumberOfRepositories(){
         return numberOfRepositories;
+    }
+
+    public GitHubAPIRequest numberOfRepositories(String numberOfRepositories){
+        this.numberOfRepositories = numberOfRepositories;
+        return this;
+    }
+
+    public void setNumberOfRepositories(String numberOfRepositories){
+        this.numberOfRepositories = numberOfRepositories;
     }
     
     public String getLocation(){
         return location;
     }
+
+    public GitHubAPIRequest location(String location){
+        this.location = location;
+        return this;
+    }
+
+    public void setLocation(String location){
+        this.location = location;
+    }
     
     public String getJoinedBeforeDate(){
         return joinedBeforeDate;
     }
+
+    public GitHubAPIRequest joinedBeforeDate(String joinedBeforeDate){
+        this.joinedBeforeDate = joinedBeforeDate;
+        return this;
+    }
+
+    public void setJoinedBeforeDate(String joinedBeforeDate){
+        this.joinedBeforeDate = joinedBeforeDate;
+    }
     
     public String getProgrammingLanguage(){
         return programmingLanguage;
+    }
+
+    public GitHubAPIRequest programmingLanguage(String programmingLanguage){
+        this.programmingLanguage = programmingLanguage;
+        return this;
+    }
+
+    public void setProgrammingLanguage(String programmingLanguage){
+        this.programmingLanguage = programmingLanguage;
     }
     
     public String getNumberOfFollowers(){
         return numberOfFollowers;
     }
 
+    public GitHubAPIRequest numberOfFollowers(String numberOfFollowers){
+        this.numberOfFollowers = numberOfFollowers;
+        return this;
+    }
+
+    public void setNumberOfFollowers(String numberOfFollowers){
+        this.numberOfFollowers = numberOfFollowers;
+    }
+
     public boolean getRequestedContributionCount(){
         return requestedContributionCount;
     }
 
+    public GitHubAPIRequest requestedContributionCount(boolean requestedContributionCount){
+        this.requestedContributionCount = requestedContributionCount;
+        return this;
+    }
+
+    public void setRequestedContributionCount(boolean requestedContributionCount){
+        this.requestedContributionCount = requestedContributionCount;
+    }
+
     public int getMaxNumberOfUserLookups(){
         return maxNumberOfUserLookups;
+    }
+
+    public GitHubAPIRequest maxNumberOfUserLookups(int maxNumberOfUserLookups){
+        this.maxNumberOfUserLookups = maxNumberOfUserLookups;
+        return this;
+    }
+
+    public void setMaxNumberOfUserLookups(int maxNumberOfUserLookups){
+        this.maxNumberOfUserLookups = maxNumberOfUserLookups;
     }
 
     @Override

--- a/src/main/java/org/project36/qualopt/service/github/GitHubAPIService.java
+++ b/src/main/java/org/project36/qualopt/service/github/GitHubAPIService.java
@@ -1,0 +1,232 @@
+package org.project36.qualopt.service.github;
+
+import org.project36.qualopt.domain.Participant;
+import org.project36.qualopt.service.github.GitHubAPIRequest;
+import org.project36.qualopt.repository.ParticipantRepository;
+import org.project36.qualopt.web.rest.errors.GHRateLimitReachedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.kohsuke.github.*;
+import java.io.IOException;
+import java.lang.Integer;
+import java.util.List;
+
+
+public class GitHubAPIService{
+
+    private final Logger log = LoggerFactory.getLogger(GitHubAPIService.class);
+
+    private final ParticipantRepository participantRepository;
+
+	private GitHubAPIRequest gitHubAPIRequest;
+
+    public GitHubAPIService(ParticipantRepository participantRepository){
+        this.participantRepository = participantRepository;
+    }
+    
+    /**
+     * Method that is called by the Resource Handler in order to pass in the API request.
+     * 
+     * An extra layer of misdirection has been added to support mocking easier - we instead
+     * mock the sendGitHubAPIUserSearch() method as this has no arguments, allowing it to
+     * be mocked by Mockit much easier.
+     */
+    public void startGitHubAPIUserSearch(GitHubAPIRequest gitHubAPIRequest) throws IOException, GHException, GHRateLimitReachedException {
+        this.gitHubAPIRequest = gitHubAPIRequest;
+        sendGitHubAPIUserSearch(); // Uses the gitHubAPIRequest field, which can be mocked! 
+    }
+
+    /**
+     * Method to connect to the GitHub API and subsequently send the user search request. Uses
+     * the kohsuke.github maven repository in order to provide an object model for the different GitHub
+     * resources. Please refer to http://github-api.kohsuke.org/apidocs/index.html for more information.
+     * 
+     * NOTE: THIS METHOD IS MOCKED DURING UNIT TESTING TO SIMPLY RETURN NOTHING OR A RELEVANT EXCEPTION.
+     * Don't just merge this method into startGitHubAPIUserSearch().
+     * 
+     * TODO: Add a timeout in this method/surrounding this method to make the call more robust in case of network failure
+     * TODO: Add ability to connect using logged in credentials to increase API calls per hour
+     * 
+     * @param gitHubAPIRequest the infomration from the API form that the user submitted
+     * @throws IOException if connection unable to be established
+     * @throws GHException if request was rejected by the API
+     * @throws GHRateLimitReachedException custom exception thrown if API call limit reached for this hour.
+     */
+    public void sendGitHubAPIUserSearch() throws IOException, GHException, GHRateLimitReachedException {
+        GitHub github = GitHub.connectAnonymously();
+        log.debug("Connected to GitHub Anonymously");
+
+        int currentRateLimit = github.getRateLimit().remaining;
+        currentRateLimit = checkRateLimit(currentRateLimit);
+        log.debug("Rate Limit after connecting is underestimated at = " + currentRateLimit);
+
+        GHUserSearchBuilder search = github.searchUsers();
+        buildUserSearch(search, this.gitHubAPIRequest);
+     
+        // Code for allowing for modifiable pagination; change this if it starts to page the search 
+        // results for some reason.
+        // search.withPageSize(pageSize);
+
+        // Performs the actual API query and then checks the limit
+        PagedSearchIterable<GHUser> searchResults = search.list();
+        currentRateLimit = checkRateLimit(currentRateLimit);
+
+        String totalNumberResults = Integer.toString(searchResults.getTotalCount());
+        log.debug("Total Number of Users found for current request = " + totalNumberResults);
+
+        int userLimiter = 0;
+        int maxUserLookups = this.gitHubAPIRequest.getMaxNumberOfUserLookups(); // will break out of for loop if exceeded
+        for(GHUser currentUser : searchResults){
+            userLimiter++;
+            currentRateLimit = checkRateLimit(currentRateLimit);
+            if(userLimiter > maxUserLookups){
+                log.debug("Reached the specified max user lookup from the GitHub API Form - Exiting now");
+                break;
+            }
+            try{
+                // Take the GHUser and convert them to a Participant reprenesentation and store.
+                Participant convertedParticipant = convertToParticipant(currentUser, gitHubAPIRequest, currentRateLimit);
+                participantRepository.save(convertedParticipant);
+            }catch(IOException e){
+                log.debug("Unable to convert participant, skipping");
+            }
+        }
+    }
+
+     /**
+     * Helper method to keep track of the estimated rate limit. Uses and returns int instead of querying
+     * the API every time to check the rate limit (too many network calls).
+     * 
+     * @param currentRateLimit cached int value representing the allotted API calls remaining
+     * @throws GHRateLimitReachedException custom exception thrown if API call limit reached for this hour.
+     */
+    private int checkRateLimit(int currentRateLimit) throws GHRateLimitReachedException {
+        // Want to be conservative so even if the counter says that the rate limit isn't 0, we want
+        // to terminate early in order to avoid getting stuck waiting for a API request when out of allocated calls. 
+        if(currentRateLimit <= 5){
+            throw new GHRateLimitReachedException("Rate Limit nearly reached! Prematurely aborting the request");
+        }
+        return currentRateLimit--;
+    }
+
+    /**
+     * Helper method to add the correct information to the GHUserSearchBuilder object, which
+     * is responsible for maintaining the URL used to query GitHub.
+     * 
+     * @param search the GHUserSearchBuilder used to construct the query string
+     * @param gitHubAPIRequest the infomration from the API form that the user submitted
+     */
+    private void buildUserSearch(GHUserSearchBuilder search, GitHubAPIRequest gitHubAPIRequest) {
+        switch(gitHubAPIRequest.getUserType()){
+            case USER:
+                search.type("user");
+                break;
+            case ORG:
+                search.type("org");
+                break;
+            case NOPREFERENCE:
+                // Don't need to add anything to the search term
+                break;
+        }
+
+        if(gitHubAPIRequest.getKeyword() != null){
+            search.q(gitHubAPIRequest.getKeyword());
+        }
+
+        if(gitHubAPIRequest.getNumberOfRepositories() != null){
+            search.repos(gitHubAPIRequest.getNumberOfRepositories());
+        }
+
+        if(gitHubAPIRequest.getLocation() != null){
+            search.location(gitHubAPIRequest.getLocation());
+        }
+
+        if(gitHubAPIRequest.getJoinedBeforeDate() != null){
+            search.created(gitHubAPIRequest.getJoinedBeforeDate());
+        }
+
+        if(gitHubAPIRequest.getProgrammingLanguage() != null){
+            search.language(gitHubAPIRequest.getProgrammingLanguage());
+        }
+
+        if(gitHubAPIRequest.getNumberOfFollowers() != null){
+            search.followers(gitHubAPIRequest.getNumberOfFollowers());
+        }
+	}
+
+    /**
+     * Helper method to convert a GitHub user representation to a Participant.
+     * Encapsulates any changes to the Participant class - simply add extra function calls
+     * on the convertedParticipant object within this function
+     * 
+     * TODO: IMPROVE THE CONTRIBUTION COUNT CHECK - currently does far too many calls as a result of REST limitations 
+     *       solution = switch to GraphQL?
+     * TODO: Currently just setting fake email address for safety. To change this to produce participants with real emails:
+     *      convertedParticipant.email(ghUser.getEmail()) - but check the kohsuke.github javadocs for most up to date implementation.
+     * 
+     * @param ghUser the current user to build a particpat out of
+     * @param gitHubAPIRequest the infomration from the API form that the user submitted
+     * @param currentRateLimit cached int value representing the allotted API calls remaining
+     * @throws IOException if network problem occurs
+     */
+	private Participant convertToParticipant(GHUser ghUser, GitHubAPIRequest gitHubAPIRequest, int currentRateLimit) throws IOException {
+        Participant convertedParticipant = new Participant();
+
+        // Set all the basic fields possible
+        convertedParticipant
+            .email(ghUser.getLogin()+"@fake.email.co.nz")
+            .occupation(ghUser.getCompany())
+            .location(ghUser.getLocation())
+            .numberOfRepositories(ghUser.getPublicRepoCount());
+        
+        // Currently, will set the page size and do a single REST request to get a number of repositories
+        // and set the programming language to the first language its able to find.
+        PagedIterable<GHRepository> allRepos = ghUser.listRepositories();
+        int numberOfReposToCheck = 10; // Arbitrary number to check - defines the number of repos obtained per page! 
+        PagedIterator<GHRepository> repoIterator = allRepos.withPageSize(numberOfReposToCheck).iterator();
+        String firstProgrammingLanguageFound = null;
+        for(int i = 0; i < numberOfReposToCheck; i++){
+            if(firstProgrammingLanguageFound == null){
+                if(repoIterator.hasNext()){
+                    GHRepository checkRepo = repoIterator.next();
+                    firstProgrammingLanguageFound = checkRepo.getLanguage();
+                }
+            }else{
+                // the checkRepo variable also has #listLanguages() to get multiple languages if we wanted that
+                convertedParticipant.programmingLanguage(firstProgrammingLanguageFound);
+                break;
+            }
+        }
+        
+        // User must explicitly specify they want Contribution Count on form, else this is skipped.
+        if(gitHubAPIRequest.getRequestedContributionCount()){
+            log.debug("BEGINNING CONTRIBUTION COUNT - EXTREMELY NETWORK INTENSIVE!!!");
+            allRepos = ghUser.listRepositories(ghUser.getPublicRepoCount()); // Set page size to number of repos for reducing request count
+            int contributionCounter = 0;
+
+            // This is the area with unfortunate consequences - the REST API only exposes repositories, meaning
+            // you must iterate through each of the repos that a user has to get their total contribution count, 
+            // and you then must find them as a contributor in each repository. This is EXTREMELY inefficient -
+            // an unfortunate consequence of using a pure REST API architecture.
+            // TODO: Could submit a feature request/query to the maintainer of the GitHub API maven repoistory being used OR switch to GraphQL
+            for(GHRepository repo : allRepos){
+                // Check rate limit EACH time we try a new repo
+                currentRateLimit = checkRateLimit(currentRateLimit);
+
+                // Large page sizes (1000 contributors per page, but each contributor is very small) have been used, 
+                // to avoid having to page a single request for contributors over and over
+                PagedIterable<GHRepository.Contributor> contributors = repo.listContributors().withPageSize(1000);
+                List<GHRepository.Contributor> contributorsList = contributors.withPageSize(1000).asList();
+                int indexCheck = contributorsList.indexOf(ghUser); // Have to index in the contributor list
+                if(indexCheck >= 0){
+                    GHRepository.Contributor currentUserAsContributor = contributorsList.get(indexCheck); // Look up the same contributor here
+                    int userContributionsToCurrentRepo = currentUserAsContributor.getContributions();
+                    log.debug("Found this many contributions for this repo: "+userContributionsToCurrentRepo);
+                    contributionCounter += userContributionsToCurrentRepo;
+                }
+            }
+            convertedParticipant.numberOfContributions(contributionCounter);
+        }
+        return convertedParticipant;
+    }
+ }

--- a/src/main/java/org/project36/qualopt/web/rest/GitHubResource.java
+++ b/src/main/java/org/project36/qualopt/web/rest/GitHubResource.java
@@ -1,19 +1,18 @@
 package org.project36.qualopt.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import org.project36.qualopt.domain.Participant;
 import org.project36.qualopt.service.github.GitHubAPIRequest;
+import org.project36.qualopt.service.github.GitHubAPIService;
 import org.project36.qualopt.repository.ParticipantRepository;
 import org.project36.qualopt.web.rest.errors.GHRateLimitReachedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.kohsuke.github.*;
 import java.io.IOException;
-import java.lang.Integer;
 import java.net.URISyntaxException;
-import java.util.List;
 
 /**
  * REST controller for managing Participant.
@@ -22,12 +21,16 @@ import java.util.List;
 @RequestMapping("/api")
 public class GitHubResource {
 
+    public static final String ERROR_MESSAGE_WHEN_CANNOT_CONNECT = "Error when connecting to the GitHub API - ";
+    public static final String ERROR_MESSAGE_WHEN_GITHUB_FAIL = "Error when contacting the GitHub API - ";
+    public static final String ERROR_MESSAGE_WHEN_API_LIMIT_EXCEEDED = "Reached GitHub API Rate Limit - ";
+
     private final Logger log = LoggerFactory.getLogger(GitHubResource.class);
 
-    private final ParticipantRepository participantRepository;
+    private GitHubAPIService gitHubAPIService;
 
     public GitHubResource(ParticipantRepository participantRepository) {
-        this.participantRepository = participantRepository;
+        this.gitHubAPIService = new GitHubAPIService(participantRepository);
     }
      
      /**
@@ -43,213 +46,31 @@ public class GitHubResource {
     public ResponseEntity<String> createGitHubAPIUserSearch(@RequestBody GitHubAPIRequest gitHubAPIRequest) throws URISyntaxException {
         log.debug("REST request to send GitHub API user search : {}", gitHubAPIRequest.toString());
         try{
-            sendGitHubAPIUserSearch(gitHubAPIRequest);
+            this.gitHubAPIService.startGitHubAPIUserSearch(gitHubAPIRequest);
         }catch(IOException e){
             log.debug("Unable To Connect to the GitHub API");
-            return ResponseEntity.badRequest()
-                .body("Error when contacting the GitHub API - " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ERROR_MESSAGE_WHEN_CANNOT_CONNECT + e.getMessage());
         }catch(GHException e) {
             log.debug("Error sending GitHub API Request, but was able to connect");
             return ResponseEntity.badRequest()
-                .body("Error when contacting the GitHub API - " + e.getMessage());
+                .body(ERROR_MESSAGE_WHEN_GITHUB_FAIL + e.getMessage());
         }catch(GHRateLimitReachedException e){
             log.debug("Error contacting GitHub API - Reached API Rate Limit");
-            return ResponseEntity.badRequest()
-                .body("Error contacting GitHub API - Reached API Rate Limit");
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .body(ERROR_MESSAGE_WHEN_API_LIMIT_EXCEEDED + e.getMessage());
         }
-        log.debug("Succesfully completed GitHub API user searcgh, sending an OK HTTP Request");
+        log.debug("Succesfully completed GitHub API user search, sending an OK HTTP Request");
         return ResponseEntity.ok()
             .body(gitHubAPIRequest.toString());
-    }
+    } 
 
     /**
-     * Helper method to connect to the GitHub API and subsequently send the user search request. Uses
-     * the kohsuke.github maven repository in order to provide an object model for the different GitHub
-     * resources. Please refer to http://github-api.kohsuke.org/apidocs/index.html for more information.
-     * 
-     * TODO: Add a timeout in this method/surrounding this method to make the call more robust in case of network failure
-     * TODO: Add ability to connect using logged in credentials to increase API calls per hour
-     * 
-     * @param gitHubAPIRequest the infomration from the API form that the user submitted
-     * @throws IOException if connection unable to be established
-     * @throws GHException if request was rejected by the API
-     * @throws GHRateLimitReachedException custom exception thrown if API call limit reached for this hour.
+     * Method used to promote testability - can mock GitHubAPIService and set it
+     * with this method. Thus, when a POST call is made to the ResourceHandler we're able
+     * to change the behaviour (ie. avoid making network calls).
      */
-    private void sendGitHubAPIUserSearch(GitHubAPIRequest gitHubAPIRequest) throws IOException, GHException, GHRateLimitReachedException {
-        GitHub github = GitHub.connectAnonymously();
-        log.debug("Connected to GitHub Anonymously");
-
-        int currentRateLimit = github.getRateLimit().remaining;
-        currentRateLimit = checkRateLimit(currentRateLimit);
-        log.debug("Rate Limit after connecting is underestimated at = " + currentRateLimit);
-
-        GHUserSearchBuilder search = github.searchUsers();
-        buildUserSearch(search, gitHubAPIRequest);
-     
-        // Code for allowing for modifiable pagination; change this if it starts to page the search 
-        // results for some reason.
-        // search.withPageSize(pageSize);
-
-        // Performs the actual API query and then checks the limit
-        PagedSearchIterable<GHUser> searchResults = search.list();
-        currentRateLimit = checkRateLimit(currentRateLimit);
-
-        String totalNumberResults = Integer.toString(searchResults.getTotalCount());
-        log.debug("Total Number of Users found for current request = " + totalNumberResults);
-
-        int userLimiter = 0;
-        int maxUserLookups = gitHubAPIRequest.getMaxNumberOfUserLookups(); // will break out of for loop if exceeded
-        for(GHUser currentUser : searchResults){
-            userLimiter++;
-            currentRateLimit = checkRateLimit(currentRateLimit);
-            if(userLimiter > maxUserLookups){
-                log.debug("Reached the specified max user lookup from the GitHub API Form - Exiting now");
-                break;
-            }
-            try{
-                // Take the GHUser and convert them to a Participant reprenesentation and store.
-                Participant convertedParticipant = convertToParticipant(currentUser, gitHubAPIRequest, currentRateLimit);
-                participantRepository.save(convertedParticipant);
-            }catch(IOException e){
-                log.debug("Unable to convert participant, skipping");
-            }
-        }
-    }
-
-     /**
-     * Helper method to keep track of the estimated rate limit. Uses and returns int instead of querying
-     * the API every time to check the rate limit (too many network calls).
-     * 
-     * @param currentRateLimit cached int value representing the allotted API calls remaining
-     * @throws GHRateLimitReachedException custom exception thrown if API call limit reached for this hour.
-     */
-    private int checkRateLimit(int currentRateLimit) throws GHRateLimitReachedException {
-        // Want to be conservative so even if the counter says that the rate limit isn't 0, we want
-        // to terminate early in order to avoid getting stuck waiting for a API request when out of allocated calls. 
-        if(currentRateLimit <= 5){
-            throw new GHRateLimitReachedException("Rate Limit nearly reached! Prematurely aborting the request");
-        }
-        return currentRateLimit--;
-    }
-
-    /**
-     * Helper method to add the correct information to the GHUserSearchBuilder object, which
-     * is responsible for maintaining the URL used to query GitHub.
-     * 
-     * @param search the GHUserSearchBuilder used to construct the query string
-     * @param gitHubAPIRequest the infomration from the API form that the user submitted
-     */
-    private void buildUserSearch(GHUserSearchBuilder search, GitHubAPIRequest gitHubAPIRequest) {
-        switch(gitHubAPIRequest.getUserType()){
-            case USER:
-                search.type("user");
-                break;
-            case ORG:
-                search.type("org");
-                break;
-            case NOPREFERENCE:
-                // Don't need to add anything to the search term
-                break;
-        }
-
-        if(gitHubAPIRequest.getKeyword() != null){
-            search.q(gitHubAPIRequest.getKeyword());
-        }
-
-        if(gitHubAPIRequest.getNumberOfRepositories() != null){
-            search.repos(gitHubAPIRequest.getNumberOfRepositories());
-        }
-
-        if(gitHubAPIRequest.getLocation() != null){
-            search.location(gitHubAPIRequest.getLocation());
-        }
-
-        if(gitHubAPIRequest.getJoinedBeforeDate() != null){
-            search.created(gitHubAPIRequest.getJoinedBeforeDate());
-        }
-
-        if(gitHubAPIRequest.getProgrammingLanguage() != null){
-            search.language(gitHubAPIRequest.getProgrammingLanguage());
-        }
-
-        if(gitHubAPIRequest.getNumberOfFollowers() != null){
-            search.followers(gitHubAPIRequest.getNumberOfFollowers());
-        }
-	}
-
-    /**
-     * Helper method to convert a GitHub user representation to a Participant.
-     * Encapsulates any changes to the Participant class - simply add extra function calls
-     * on the convertedParticipant object within this function
-     * 
-     * TODO: IMPROVE THE CONTRIBUTION COUNT CHECK - currently does far too many calls as a result of REST limitations 
-     *       solution = switch to GraphQL?
-     * TODO: Currently just setting fake email address for safety. To change this to produce participants with real emails:
-     *      convertedParticipant.email(ghUser.getEmail()) - but check the kohsuke.github javadocs for most up to date implementation.
-     * 
-     * @param ghUser the current user to build a particpat out of
-     * @param gitHubAPIRequest the infomration from the API form that the user submitted
-     * @param currentRateLimit cached int value representing the allotted API calls remaining
-     * @throws IOException if network problem occurs
-     */
-	private Participant convertToParticipant(GHUser ghUser, GitHubAPIRequest gitHubAPIRequest, int currentRateLimit) throws IOException {
-        Participant convertedParticipant = new Participant();
-
-        // Set all the basic fields possible
-        convertedParticipant
-            .email(ghUser.getLogin()+"@fake.email.co.nz")
-            .occupation(ghUser.getCompany())
-            .location(ghUser.getLocation())
-            .numberOfRepositories(ghUser.getPublicRepoCount());
-        
-        // Currently, will set the page size and do a single REST request to get a number of repositories
-        // and set the programming language to the first language its able to find.
-        PagedIterable<GHRepository> allRepos = ghUser.listRepositories();
-        int numberOfReposToCheck = 10; // Arbitrary number to check - defines the number of repos obtained per page! 
-        PagedIterator<GHRepository> repoIterator = allRepos.withPageSize(numberOfReposToCheck).iterator();
-        String firstProgrammingLanguageFound = null;
-        for(int i = 0; i < numberOfReposToCheck; i++){
-            if(firstProgrammingLanguageFound == null){
-                if(repoIterator.hasNext()){
-                    GHRepository checkRepo = repoIterator.next();
-                    firstProgrammingLanguageFound = checkRepo.getLanguage();
-                }
-            }else{
-                // the checkRepo variable also has #listLanguages() to get multiple languages if we wanted that
-                convertedParticipant.programmingLanguage(firstProgrammingLanguageFound);
-                break;
-            }
-        }
-        
-        // User must explicitly specify they want Contribution Count on form, else this is skipped.
-        if(gitHubAPIRequest.getRequestedContributionCount()){
-            log.debug("BEGINNING CONTRIBUTION COUNT - EXTREMELY NETWORK INTENSIVE!!!");
-            allRepos = ghUser.listRepositories(ghUser.getPublicRepoCount()); // Set page size to number of repos for reducing request count
-            int contributionCounter = 0;
-
-            // This is the area with unfortunate consequences - the REST API only exposes repositories, meaning
-            // you must iterate through each of the repos that a user has to get their total contribution count, 
-            // and you then must find them as a contributor in each repository. This is EXTREMELY inefficient -
-            // an unfortunate consequence of using a pure REST API architecture.
-            // TODO: Could submit a feature request/query to the maintainer of the GitHub API maven repoistory being used OR switch to GraphQL
-            for(GHRepository repo : allRepos){
-                // Check rate limit EACH time we try a new repo
-                currentRateLimit = checkRateLimit(currentRateLimit);
-
-                // Large page sizes (1000 contributors per page, but each contributor is very small) have been used, 
-                // to avoid having to page a single request for contributors over and over
-                PagedIterable<GHRepository.Contributor> contributors = repo.listContributors().withPageSize(1000);
-                List<GHRepository.Contributor> contributorsList = contributors.withPageSize(1000).asList();
-                int indexCheck = contributorsList.indexOf(ghUser); // Have to index in the contributor list
-                if(indexCheck >= 0){
-                    GHRepository.Contributor currentUserAsContributor = contributorsList.get(indexCheck); // Look up the same contributor here
-                    int userContributionsToCurrentRepo = currentUserAsContributor.getContributions();
-                    log.debug("Found this many contributions for this repo: "+userContributionsToCurrentRepo);
-                    contributionCounter += userContributionsToCurrentRepo;
-                }
-            }
-            convertedParticipant.numberOfContributions(contributionCounter);
-        }
-        return convertedParticipant;
+    public void setGitHubAPIServiceMock(GitHubAPIService gitHubAPIService){
+        this.gitHubAPIService = gitHubAPIService;
     }
 }

--- a/src/test/java/org/project36/qualopt/web/rest/GitHubResourceIntTest.java
+++ b/src/test/java/org/project36/qualopt/web/rest/GitHubResourceIntTest.java
@@ -1,0 +1,243 @@
+package org.project36.qualopt.web.rest;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.github.GHException;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.project36.qualopt.QualOptApp;
+import org.project36.qualopt.repository.ParticipantRepository;
+import org.project36.qualopt.service.github.GitHubAPIRequest;
+import org.project36.qualopt.service.github.GitHubAPIService;
+import org.project36.qualopt.service.github.GitHubUserType;
+import org.project36.qualopt.web.rest.errors.ExceptionTranslator;
+import org.project36.qualopt.web.rest.errors.GHRateLimitReachedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Test class for the GitHubResource REST controller.
+ * 
+ * These unit test insert a mock GitHubAPIService object to the REST controller, allowing control on the methods that 
+ * make network calls. In doing so, we ensure that these tests do not make the actual API calls, as this would be 
+ * potentially non-determinant and would be too long for a unit test. 
+ * 
+ * Note: This class is used to test the REST Controller, not the GitHub API domain model used - that has
+ * it's own set of tests which can be found on its website. Further, this does not test the creation of making
+ * the participants that would be returned from the GitHub API - as this is tested by the ParticipantResourceIntTest series
+ * of tests.
+ *
+ * @see GitHubResource
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = QualOptApp.class)
+public class GitHubResourceIntTest {
+
+    private static final GitHubUserType DEFAULT_USER_TYPE = GitHubUserType.NOPREFERENCE;
+
+    private static final String DEFAULT_KEYWORD = "AAAAAAAAAA";
+
+    private static final String DEFAULT_NUMBER_OF_REPOSITORIES = "AAAA";
+
+    private static final String DEFAULT_LOCATION = "AAAAAAAAAA";
+
+    private static final String DEFAULT_JOINED_BEFORE_DATE = "AAAAAAAAAA";
+
+    private static final String DEFAULT_PROGRAMMING_LANGUAGE = "C#";
+
+    private static final String DEFAULT_NUMBER_OF_FOLLOWERS = "AAAAAAAAAAAAA";
+
+    private static final boolean DEFAULT_REQUEST_CONTRIBUTION_COUNT = false;
+
+    private static final int DEAFULT_MAX_NUMBER_OF_USER_LOOKUPS = 0;
+   
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Autowired
+    private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+    @Autowired
+    private PageableHandlerMethodArgumentResolver pageableArgumentResolver;
+
+    @Autowired
+    private ExceptionTranslator exceptionTranslator;
+
+    private MockMvc restGitHubAPIMockMvc;
+
+    @InjectMocks
+    private GitHubResource gitHubResource;
+
+    /**
+     * Enum to pass in to define what the GitHubAPIService mock should exhibit
+     */
+    private enum GitHubAPIServiceMockBehaviour {
+        SUCCESS,
+        NETWORK_FAIL,
+        GITHUB_FAIL,
+        RATE_LIMIT_EXCEEDED
+    }
+
+    /**
+     * Setup method to produce a MockMVC of the GitHubResource REST controller
+     * 
+     * NOTE: each test must also place in its own implementation specifc mock, this method
+     * simply places a deafult "success" mock in case future tests forget to add a mock (don't 
+     * ever want to do a network call while testing)
+     */
+    @Before
+    public void setupWithMock() throws Exception{
+        MockitoAnnotations.initMocks(this);
+        this.gitHubResource = new GitHubResource(participantRepository);
+        this.gitHubResource.setGitHubAPIServiceMock(createMockGitHubAPIService(GitHubAPIServiceMockBehaviour.SUCCESS));
+        this.restGitHubAPIMockMvc = MockMvcBuilders.standaloneSetup(this.gitHubResource)
+            .setCustomArgumentResolvers(pageableArgumentResolver)
+            .setControllerAdvice(exceptionTranslator)
+            .setMessageConverters(jacksonMessageConverter).build();
+    }
+
+    /**
+     * Create a default GitHubAPIRequest
+     * 
+     * Should be used to simply send to the resource and NOT used to actually query the API - this
+     * would not turn any reasonable results. This should be used for testing alongside mocking
+     * the GitHubAPIService object.
+     */
+    public static GitHubAPIRequest createGitHubAPIRequest() {
+        GitHubAPIRequest gitHubAPIRequest = new GitHubAPIRequest()
+            .userType(DEFAULT_USER_TYPE)
+            .keyword(DEFAULT_KEYWORD)
+            .numberOfRepositories(DEFAULT_NUMBER_OF_REPOSITORIES)
+            .location(DEFAULT_LOCATION)
+            .joinedBeforeDate(DEFAULT_JOINED_BEFORE_DATE)
+            .programmingLanguage(DEFAULT_PROGRAMMING_LANGUAGE)
+            .numberOfFollowers(DEFAULT_NUMBER_OF_FOLLOWERS)
+            .requestedContributionCount(DEFAULT_REQUEST_CONTRIBUTION_COUNT)
+            .maxNumberOfUserLookups(DEAFULT_MAX_NUMBER_OF_USER_LOOKUPS);
+        gitHubAPIRequest.setMuleId(1);
+        return gitHubAPIRequest;
+    }
+
+    /**
+     * Helper method to return a mock that exhibits testable behaviour without having to perform
+     * the network call. This mock must be inserted into the GitHubResource REST controller to allow
+     * for it to exhibit the behaviour.
+     * 
+     * Mocking the object is facilitated through Mockito - the framework makes a spy (partial mock) and 
+     * then mocksout the sendGitHubAPIUserSearch() method. It will vary the behavior of this method 
+     * depending on the type of behavior that should be tested (represented by the enum). The resource 
+     * handler is mocked up by the setup method.
+     */
+    public GitHubAPIService createMockGitHubAPIService(GitHubAPIServiceMockBehaviour mockBehaviour) throws Exception{
+        GitHubAPIService gitHubAPIServiceMock = spy(new GitHubAPIService(participantRepository));
+        
+        // Add the mock behavior, currently just mocking out the one method responsible for the network 
+        // call, it will instead just "completes" the method by do nothing, or throws an exception to 
+        // simulate some kind of failure
+        switch(mockBehaviour){
+            case SUCCESS:
+                doNothing().when(gitHubAPIServiceMock).sendGitHubAPIUserSearch();
+                break;
+            case NETWORK_FAIL:
+                doThrow(new IOException()).when(gitHubAPIServiceMock).sendGitHubAPIUserSearch();
+                break;
+            case GITHUB_FAIL:
+                doThrow(new GHException("")).when(gitHubAPIServiceMock).sendGitHubAPIUserSearch();
+                break;
+            case RATE_LIMIT_EXCEEDED:
+                doThrow(new GHRateLimitReachedException("")).when(gitHubAPIServiceMock).sendGitHubAPIUserSearch();
+                break;
+            default:
+                doNothing().when(gitHubAPIServiceMock).sendGitHubAPIUserSearch();
+                break;
+        }
+        return gitHubAPIServiceMock;
+    }
+
+    /**
+     * Test for basic behavior, when there is no failure or rate limit exceeded
+     */
+    @Test
+    @Transactional
+    public void sendGitHubRequestBasic() throws Exception {
+        GitHubAPIRequest testRequest = GitHubResourceIntTest.createGitHubAPIRequest();
+
+        this.gitHubResource.setGitHubAPIServiceMock(createMockGitHubAPIService(GitHubAPIServiceMockBehaviour.SUCCESS));
+        
+        restGitHubAPIMockMvc.perform(post("/api/gitHubQuery")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(testRequest)))
+            .andExpect(status().isOk());
+    }
+
+    /**
+     * Test for when a network failure occurs during sending the GitHub API request
+     */
+    @Test
+    @Transactional
+    public void sendGitHubRequestAndNetworkFail() throws Exception {
+        GitHubAPIRequest testRequest = GitHubResourceIntTest.createGitHubAPIRequest();
+
+        this.gitHubResource.setGitHubAPIServiceMock(createMockGitHubAPIService(GitHubAPIServiceMockBehaviour.NETWORK_FAIL));
+        
+        MvcResult result = restGitHubAPIMockMvc.perform(post("/api/gitHubQuery")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(testRequest)))
+            .andExpect(status().isUnauthorized())
+            .andReturn();
+        assertTrue(result.getResponse().getContentAsString().contains(GitHubResource.ERROR_MESSAGE_WHEN_CANNOT_CONNECT));
+    }
+
+    /**
+     * Test for when there is a failure with the GitHub API, but no network failure occurs
+     */
+    @Test
+    @Transactional
+    public void sendGitHubRequestAndGHFail() throws Exception {
+        GitHubAPIRequest testRequest = GitHubResourceIntTest.createGitHubAPIRequest();
+
+        this.gitHubResource.setGitHubAPIServiceMock(createMockGitHubAPIService(GitHubAPIServiceMockBehaviour.GITHUB_FAIL));
+        
+        MvcResult result = restGitHubAPIMockMvc.perform(post("/api/gitHubQuery")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(testRequest)))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+        assertTrue(result.getResponse().getContentAsString().contains(GitHubResource.ERROR_MESSAGE_WHEN_GITHUB_FAIL));
+    }
+
+    /**
+     * Test for when the rate limit is exceeded while sending a GitHub API request
+     */
+    @Test
+    @Transactional
+    public void sendGitHubRequestAndRateLimitExceeded() throws Exception {
+        GitHubAPIRequest testRequest = GitHubResourceIntTest.createGitHubAPIRequest();
+
+        this.gitHubResource.setGitHubAPIServiceMock(createMockGitHubAPIService(GitHubAPIServiceMockBehaviour.RATE_LIMIT_EXCEEDED));
+        
+        MvcResult result = restGitHubAPIMockMvc.perform(post("/api/gitHubQuery")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(testRequest)))
+            .andExpect(status().isTooManyRequests())
+            .andReturn();
+        assertTrue(result.getResponse().getContentAsString().contains(GitHubResource.ERROR_MESSAGE_WHEN_API_LIMIT_EXCEEDED));
+    }
+}


### PR DESCRIPTION
This contains the unit tests and necessary refactoring needed to test the functionality introduced by the first pull request for #40. This includes introducing a new class and making some changes to the original code to promote testability (ie. allowing for adding a mock implementation to avoid making GitHub API calls over the network during testing). 

This completes the work needed for #40.

**Please note: #41 will be impacted by this change, as refactoring has occurred to introduce the misdirection needed to allow Mockito to mock the method that is responsible for sending network calls. This change also depends on having #131 pulled in (had the Lob annotation for allowing mvnw test to work)**

## Summary of Changes
- Introduced a new test class `GitHubResourceIntTest.java` that contains the new unit tests introduced to test the `GitHubResouce` REST Controller
- Added the appropriate setter method to `GitHubAPIRequest` to allow tests to construct these objects cleanly
- Introduce `GitHubAPIService`, which hosts all of the functionality that `GitHubResource` used to use to make the actual network calls to the GitHub API. It also introduces the necessary misdirection to allow for mocking a method without a parameter (refer to the comments in the code for technical details)
- Add a new field and setter method to `GitHubResource` to allow for a mocked version of `GitHubAPIService` to be substituted in

## Summary of how Testing Works
The idea of the unit testing class introduced in this pull request is to set up the MockMVC controller with a default `GitHubResource`, and then each method is able to request a mock `GitHubAPIService` object (from the `createMockGitHubAPIService()` method).

These mocks simply override the behavior of the `sendGitHubAPIUserSearch()`, which consists of all the network calls to the GitHub API. It will simply do nothing or throw some kind of exception - this simulates either success or the various failures that could occur during execution.

Use of `MockMVC` allow testing of the web service aspects, ie. actually sending a POST request with the body of the request containing the `GitHubAPIRequest` (which is what is expected from the front-end).

The Mockito framework has been leveraged to provide the mocking capabilities - as it provides much more readable and maintainable code. No specific mocks classes have been made, as the framework is able to wrap the object and provide partial mocking capabilities.

If you have any questions about these changes, feel free to let me know. 