### PR TITLE
Issue #15 - Colour misassociation between back button and view button 

### DIFF
--- a/src/main/webapp/app/entities/study/study-detail.component.css
+++ b/src/main/webapp/app/entities/study/study-detail.component.css
@@ -1,0 +1,4 @@
+.btn-info{
+    background-color:LightSlateGrey; 
+    border-color:LightSlateGrey
+}

--- a/src/main/webapp/app/entities/study/study-detail.component.ts
+++ b/src/main/webapp/app/entities/study/study-detail.component.ts
@@ -8,7 +8,8 @@ import { StudyService } from './study.service';
 
 @Component({
     selector: 'jhi-study-detail',
-    templateUrl: './study-detail.component.html'
+    templateUrl: './study-detail.component.html',
+    styleUrls:['./study-detail.component.css']
 })
 export class StudyDetailComponent implements OnInit, OnDestroy {
 

--- a/src/main/webapp/app/entities/study/study.component.html
+++ b/src/main/webapp/app/entities/study/study.component.html
@@ -57,6 +57,12 @@
                       <span class="fa fa-remove"></span>
                       <span class="hidden-md-down">Delete</span>
                   </button>
+                  <button type="submit"
+                  [routerLink]="['/', { outlets: { popup: 'study/'+ study.id + '/confirmSend'} }]"
+                  replaceUrl="true"
+                  class="btn btn-success btn-sm">
+                    <span class="fa fa-paper-plane"></span>&nbsp;<span> Send Invitation</span>
+                </button>
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
This issue has been completed and the colour of the back button on the individual studies page has been changed to remove the misassociation. The new UI is ready for review.

# Changes
A CSS file has been created for the study-details component. This file updates the styling of the back button to change the button colour to LightSlateGrey
# Testing 
Navigate to the individual studies page. The back button should now be LightSlateGrey and nothing else should be changed. 

The new UI is shown below

![changes](https://user-images.githubusercontent.com/22784547/37937202-1a4a2e9c-31b5-11e8-8761-859a5623e1f9.png)
