### PR TITLE
Change popup to show study name instead of identifier

### DIFF
--- a/src/main/java/org/project36/qualopt/web/rest/StudyResource.java
+++ b/src/main/java/org/project36/qualopt/web/rest/StudyResource.java
@@ -156,9 +156,10 @@ public class StudyResource {
     @DeleteMapping("/studies/{id}")
     @Timed
     public ResponseEntity<Void> deleteStudy(@PathVariable Long id) {
+        String name = this.getStudy(id).getBody().getName();
         log.debug("REST request to delete Study : {}", id);
         studyRepository.deleteById(id);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(ENTITY_NAME, id.toString())).build();
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(ENTITY_NAME, name)).build();
     }
 
     public String getCurrentUserLogin() {

--- a/src/main/java/org/project36/qualopt/web/rest/util/HeaderUtil.java
+++ b/src/main/java/org/project36/qualopt/web/rest/util/HeaderUtil.java
@@ -21,15 +21,15 @@ public final class HeaderUtil {
     }
 
     public static HttpHeaders createEntityCreationAlert(String entityName, String param) {
-        return createAlert("A new " + entityName + " is created with identifier " + param, param);
+        return createAlert("A new " + entityName + " is created with name " + param, param);
     }
 
     public static HttpHeaders createEntityUpdateAlert(String entityName, String param) {
-        return createAlert("A " + entityName + " is updated with identifier " + param, param);
+        return createAlert("A " + entityName + " is updated with name " + param, param);
     }
 
     public static HttpHeaders createEntityDeletionAlert(String entityName, String param) {
-        return createAlert("A " + entityName + " is deleted with identifier " + param, param);
+        return createAlert("A " + entityName + " is deleted with name " + param, param);
     }
 
     public static HttpHeaders createFailureAlert(String entityName, String errorKey, String defaultMessage) {


### PR DESCRIPTION
This pull request fixes issue #89.

**Popups Before** 
- Shows "New Study Created with identifier ..." 
- On delete shows study identifier instead of name

![od](https://user-images.githubusercontent.com/22588661/37946822-020d19a0-31e4-11e8-998b-ea5bddf75383.png)

**Popups After** 
- Shows "New Study Created with name ..." 
- On delete shows study name

![nd](https://user-images.githubusercontent.com/22588661/37946774-b8b25e1e-31e3-11e8-8a5e-d7e7d3e6deac.png)

The fix involved changing the popup message in HeaderUtil.java and changing the variable for message deletion popup message in StudyResources.java.