### PR TITLE
Feature/send custom invitation emails

### DIFF
--- a/.jhipster/Participant.json
+++ b/.jhipster/Participant.json
@@ -18,6 +18,14 @@
             ]
         },
         {
+            "fieldName": "firstName",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "lastName",
+            "fieldType": "String"
+        },
+        {
             "fieldName": "occupation",
             "fieldType": "String"
         },

--- a/qualopt.jh
+++ b/qualopt.jh
@@ -11,6 +11,8 @@ entity Study {
 
 entity Participant {
 	email String required,
+	firstName String,
+	lastName String,
     occupation String,
     location String,
 	programmingLanguage String,

--- a/src/main/java/org/project36/qualopt/config/social/SocialConfiguration.java
+++ b/src/main/java/org/project36/qualopt/config/social/SocialConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.social.google.connect.GoogleConnectionFactory;
 import org.springframework.social.security.AuthenticationNameUserIdSource;
 import org.springframework.social.twitter.connect.TwitterConnectionFactory;
 
+import java.lang.*;
 import io.github.jhipster.config.JHipsterProperties;
 
 import org.springframework.social.github.connect.GitHubConnectionFactory;

--- a/src/main/java/org/project36/qualopt/domain/Participant.java
+++ b/src/main/java/org/project36/qualopt/domain/Participant.java
@@ -1,15 +1,14 @@
 package org.project36.qualopt.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import javax.persistence.*;
-import javax.validation.constraints.*;
+import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A Participant.
@@ -35,6 +34,12 @@ public class Participant implements Serializable {
 
     @Column(name = "occupation")
     private String occupation;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
 
     @Column(name = "location")
     private String location;
@@ -86,7 +91,7 @@ public class Participant implements Serializable {
     }
 
     public String getOccupation() {
-        return occupation;
+        return getStringNonNull(occupation);
     }
 
     public Participant occupation(String occupation) {
@@ -99,7 +104,7 @@ public class Participant implements Serializable {
     }
 
     public String getLocation() {
-        return location;
+        return getStringNonNull(location);
     }
 
     public Participant location(String location) {
@@ -112,7 +117,7 @@ public class Participant implements Serializable {
     }
 
     public String getProgrammingLanguage() {
-        return programmingLanguage;
+        return getStringNonNull(programmingLanguage);
     }
 
     public Participant programmingLanguage(String programmingLanguage) {
@@ -174,7 +179,27 @@ public class Participant implements Serializable {
         this.studies = studies;
     }
 
-    public boolean getOptedIn() {
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getFirstName() {
+        return getStringNonNull(firstName);
+    }
+
+    public String getLastName() {
+        return getStringNonNull(lastName);
+    }
+
+    private String getStringNonNull(String s) {
+        return Objects.isNull(s) ? "" : s;
+    }
+
+      public boolean getOptedIn() {
         return this.hasOptedIn;
     }
 
@@ -229,7 +254,9 @@ public class Participant implements Serializable {
     @Override
     public String toString() {
         return "Participant{" +
-            "id=" + getId() +
+            "id=" + getId() + "'" +
+            ", firstName='" + getFirstName() + "'" +
+            ", lastName='" + getLastName() + "'" +
             ", email='" + getEmail() + "'" +
             ", occupation='" + getOccupation() + "'" +
             ", location='" + getLocation() + "'" +

--- a/src/main/java/org/project36/qualopt/domain/Study.java
+++ b/src/main/java/org/project36/qualopt/domain/Study.java
@@ -282,6 +282,7 @@ public class Study implements Serializable {
             ", incentiveType='" + getIncentiveType() + "'" +
             ", incentiveDetails='" + getIncentiveDetail() + "'" +
             ", status='" + getStatus() + "'" +
+            ", faq='" + getFaq() + "'" +
             ", emailSubject='" + getEmailSubject() + "'" +
             ", emailBody='" + getEmailBody() + "'" +
             ", bouncedMail='" + getBouncedMail() + "'" +

--- a/src/main/java/org/project36/qualopt/service/MailService.java
+++ b/src/main/java/org/project36/qualopt/service/MailService.java
@@ -1,9 +1,6 @@
 package org.project36.qualopt.service;
 
-import java.util.Locale;
-
-import javax.mail.internet.MimeMessage;
-
+import io.github.jhipster.config.JHipsterProperties;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.StringUtils;
 import org.project36.qualopt.domain.User;
@@ -17,7 +14,8 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 
-import io.github.jhipster.config.JHipsterProperties;
+import javax.mail.internet.MimeMessage;
+import java.util.Locale;
 
 /**
  * Service for sending emails.

--- a/src/main/java/org/project36/qualopt/web/rest/DocumentResource.java
+++ b/src/main/java/org/project36/qualopt/web/rest/DocumentResource.java
@@ -1,9 +1,6 @@
 package org.project36.qualopt.web.rest;
 
-import javax.persistence.EntityNotFoundException;
-
 import com.codahale.metrics.annotation.Timed;
-
 import org.apache.commons.codec.binary.Base64;
 import org.project36.qualopt.domain.Document;
 import org.project36.qualopt.repository.DocumentRepository;
@@ -17,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.persistence.EntityNotFoundException;
 
 /**
  * REST controller for managing Email.
@@ -37,11 +36,9 @@ public class DocumentResource {
     @Timed
     public ResponseEntity<Resource> downloadDocument(@PathVariable Long id) {
         Document document;
-        
         try {
             document = documentRepository.getOne(id);
-        } 
-        catch (EntityNotFoundException e) {
+        } catch (EntityNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
 
@@ -49,10 +46,10 @@ public class DocumentResource {
         ByteArrayResource resource = new ByteArrayResource(fileBlob);
 
         return ResponseEntity.ok()
-            .header("Content-Disposition", String.format("inline; filename=\"" + document.getFilename() + "\""))
+            .header("Content-Disposition", "inline; filename=\"" + document.getFilename() + "\"")
             .contentLength(fileBlob.length)
             .contentType(MediaType.parseMediaType("application/octet-stream"))
             .body(resource);
-    }
 
+        }
 }

--- a/src/main/java/org/project36/qualopt/web/rest/EmailTemplateResource.java
+++ b/src/main/java/org/project36/qualopt/web/rest/EmailTemplateResource.java
@@ -23,9 +23,9 @@ import com.codahale.metrics.annotation.Timed;
 
 /**
  * REST controller for managing Email Templates.
- * 
+ *
  * Supported operation:
- * 
+ *
  * POST: 		create an email template
  * PUT:			update an email template
  * GET:			gets all the email template
@@ -37,7 +37,7 @@ import com.codahale.metrics.annotation.Timed;
 public class EmailTemplateResource {
 
     private final Logger log = LoggerFactory.getLogger(EmailTemplateResource.class);
-    
+
     private static final String ENTITY_NAME = "email_template";
 
     private final EmailTemplateRepository emailTemplateRepository;
@@ -50,7 +50,7 @@ public class EmailTemplateResource {
      * POST  /emailTemplates : Create a new email Template.
      *
      * @param emailTemplate the email template to create
-     * @return the ResponseEntity with status 201 (Created) and with body the new email template, 
+     * @return the ResponseEntity with status 201 (Created) and with body the new email template,
      * 			or with status 400 (Bad Request) if the email has already an ID
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
@@ -82,12 +82,12 @@ public class EmailTemplateResource {
         if (emailTemplate.getId() == null) {
             return createEmail(emailTemplate);
         }
-        
+
         if (emailTemplate.getName() == null){
         	return ResponseEntity.badRequest().build();
         }
-        
-        
+
+
         EmailTemplate result = emailTemplateRepository.save(emailTemplate);
         return ResponseEntity.ok()
             .headers(HeaderUtil.createEntityUpdateAlert(ENTITY_NAME, emailTemplate.getId().toString()))

--- a/src/main/java/org/project36/qualopt/web/rest/StudyResource.java
+++ b/src/main/java/org/project36/qualopt/web/rest/StudyResource.java
@@ -142,7 +142,6 @@ public class StudyResource {
         if(study==null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
-
         StudyInfoDTO studyInfo = new StudyInfoDTO(study);
         return new ResponseEntity<>(studyInfo, HttpStatus.OK);
     }

--- a/src/main/resources/.h2.server.properties
+++ b/src/main/resources/.h2.server.properties
@@ -1,5 +1,5 @@
 #H2 Server Properties
-#Fri Mar 23 21:15:48 NZDT 2018
+#Wed Mar 28 11:23:42 NZDT 2018
 0=JHipster H2 (Memory)|org.h2.Driver|jdbc\:h2\:mem\:qualopt|QualOpt
 webAllowOthers=true
 webPort=8082

--- a/src/main/resources/config/liquibase/changelog/20170806124646_added_entity_Participant.xml
+++ b/src/main/resources/config/liquibase/changelog/20170806124646_added_entity_Participant.xml
@@ -26,6 +26,14 @@
                 <constraints nullable="false" />
             </column>
 
+            <column name="first_name" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="last_name" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
             <column name="occupation" type="varchar(255)">
                 <constraints nullable="true" />
             </column>

--- a/src/main/resources/config/liquibase/changelog/20170806142424_added_entity_Study.xml
+++ b/src/main/resources/config/liquibase/changelog/20170806142424_added_entity_Study.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
-                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <property name="now" value="now()" dbms="h2"/>
 

--- a/src/main/resources/config/liquibase/changelog/20170806142426_added_entity_Participant.xml
+++ b/src/main/resources/config/liquibase/changelog/20170806142426_added_entity_Participant.xml
@@ -26,6 +26,14 @@
                 <constraints nullable="false" />
             </column>
 
+            <column name="first_name" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="last_name" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
             <column name="occupation" type="varchar(255)">
                 <constraints nullable="true" />
             </column>

--- a/src/main/resources/config/liquibase/changelog/20180314100212_added_entity_Document.xml
+++ b/src/main/resources/config/liquibase/changelog/20180314100212_added_entity_Document.xml
@@ -3,7 +3,6 @@
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-
     <property name="now" value="now()" dbms="h2"/>
 
     <property name="now" value="now()" dbms="mysql"/>
@@ -16,7 +15,6 @@
         Added the columns for entity Study.
     -->
     <changeSet id="20180314100212-1" author="jhipster">
-
         <createTable tableName="document">
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>
@@ -31,6 +29,5 @@
                                  constraintName="fk_study_document"
                                  referencedColumnNames="id"
                                  referencedTableName="study"/>
-
     </changeSet>
 </databaseChangeLog>

--- a/src/main/webapp/app/entities/participant/participant-detail.component.html
+++ b/src/main/webapp/app/entities/participant/participant-detail.component.html
@@ -8,6 +8,14 @@
         <dd>
             <span>{{participant.email}}</span>
         </dd>
+        <dt><span>First Name</span></dt>
+        <dd>
+            <span>{{participant.firstName}}</span>
+        </dd>
+        <dt><span>Last Name</span></dt>
+        <dd>
+            <span>{{participant.lastName}}</span>
+        </dd>
         <dt><span>Occupation</span></dt>
         <dd>
             <span>{{participant.occupation}}</span>

--- a/src/main/webapp/app/entities/participant/participant-dialog.component.html
+++ b/src/main/webapp/app/entities/participant/participant-dialog.component.html
@@ -24,6 +24,16 @@
             </div>
         </div>
         <div class="form-group">
+            <label class="form-control-label" for="field_occupation">First Name</label>
+            <input type="text" class="form-control" name="occupation" id="field_firstName"
+                   [(ngModel)]="participant.firstName"  />
+        </div>
+        <div class="form-group">
+            <label class="form-control-label" for="field_occupation">Last Name</label>
+            <input type="text" class="form-control" name="occupation" id="field_lastName"
+                   [(ngModel)]="participant.lastName"  />
+        </div>
+        <div class="form-group">
             <label class="form-control-label" for="field_occupation">Occupation</label>
             <input type="text" class="form-control" name="occupation" id="field_occupation"
                 [(ngModel)]="participant.occupation"  />

--- a/src/main/webapp/app/entities/participant/participant.model.ts
+++ b/src/main/webapp/app/entities/participant/participant.model.ts
@@ -3,6 +3,8 @@ import { BaseEntity } from './../../shared';
 export class Participant implements BaseEntity {
     constructor(
         public id?: number,
+        public firstName?: string,
+        public lastName?:string,
         public email?: string,
         public occupation?: string,
         public location?: string,

--- a/src/main/webapp/app/entities/study/study-dialog.component.html
+++ b/src/main/webapp/app/entities/study/study-dialog.component.html
@@ -83,6 +83,23 @@
                     <h4 class="modal-title" id="myEmailLabel">Draft Invitation Email</h4>
                 </div>
                 <div class="modal-body">
+                    <button type="button" (click)="showCustomInfo()" class="btn">
+                        <span class="fa fa-info-circle"></span>&nbsp;
+                        <span>Customise</span>
+                    </button>
+                    <div [hidden]="hidingCustomInfo">
+                        <p class="form-text" >
+                            You can personalise the invitation email for each participant by using the following tags:
+                        </p>
+                        <ul>
+                            <li>--firstName</li>
+                            <li>--lastName</li>
+                            <li>--occupation</li>
+                            <li>--programmingLanguage</li>
+                            <li>--numberOfContributions</li>
+                            <li>--numberOfRepositories</li>
+                        </ul>
+                    </div>
                     <div class="form-group">
                         <label class="form-control-label" for="field_emailSubject">Subject</label>
                         <input type="text" class="form-control" name="emailSubject" id="field_emailSubject"

--- a/src/main/webapp/app/entities/study/study-dialog.component.ts
+++ b/src/main/webapp/app/entities/study/study-dialog.component.ts
@@ -28,6 +28,7 @@ import { Document } from '../document';
 export class StudyDialogComponent implements OnInit {
     study: Study;
     isSaving: boolean;
+    hidingCustomInfo: boolean;
 
     users: User[];
 
@@ -63,6 +64,7 @@ export class StudyDialogComponent implements OnInit {
 
     ngOnInit() {
         this.isSaving = false;
+        this.hidingCustomInfo = true;
         this.userService.query()
             .subscribe((res: ResponseWrapper) => { this.users = res.json; }, (res: ResponseWrapper) => this.onError(res.json));
         this.participantService.query()
@@ -323,6 +325,10 @@ export class StudyDialogComponent implements OnInit {
         }
     }
 
+    showCustomInfo() {
+        this.hidingCustomInfo = !this.hidingCustomInfo;
+    }
+  
     filterOptedInParticipants() {
         if (!this.participants) {
             return [];

--- a/src/test/java/org/project36/qualopt/service/StudyServiceIntTest.java
+++ b/src/test/java/org/project36/qualopt/service/StudyServiceIntTest.java
@@ -154,4 +154,45 @@ public class StudyServiceIntTest {
         assertThat(bouncedMail.size()).isEqualTo(2);
         assertThat(bouncedMail).isEqualTo(participants.stream().map(Participant::getEmail).collect(Collectors.toSet()));
     }
+
+    @Test
+    public void testSendCustomInvitationEmail() throws Exception {
+        User user = new User();
+        user.setEmail("user@email.com");
+        Participant participant = new Participant().email("participant@email.com");
+        participant.setFirstName("John");
+        participant.setLastName("Smith");
+        participant.setLocation("Auckland");
+        participant.setOccupation("Software Engineer");
+        participant.setProgrammingLanguage("Java");
+        participant.setNumberOfContributions(23);
+        participant.setNumberOfRepositories(1);
+        studyService.sendInvitationEmail(new Study()
+            .user(user)
+            .emailSubject(StudyService.CUSTOM_FIRST_NAME + ", " +
+                StudyService.CUSTOM_LAST_NAME + ", " +
+                StudyService.CUSTOM_LOCATION + ", " +
+                StudyService.CUSTOM_OCCUPATION + ", " +
+                StudyService.CUSTOM_PROGRAMMING_LANGUAGE + ", " +
+                StudyService.CUSTOM_NUMBER_OF_CONTRIBUTIONS + ", " +
+                StudyService.CUSTOM_NUMBER_OF_REPOSITORIES + ", " +
+                "testSubject")
+            .emailBody(StudyService.CUSTOM_FIRST_NAME + ", " +
+            StudyService.CUSTOM_LAST_NAME + ", " +
+            StudyService.CUSTOM_LOCATION + ", " +
+            StudyService.CUSTOM_OCCUPATION + ", " +
+            StudyService.CUSTOM_PROGRAMMING_LANGUAGE + ", " +
+            StudyService.CUSTOM_NUMBER_OF_CONTRIBUTIONS + ", " +
+            StudyService.CUSTOM_NUMBER_OF_REPOSITORIES + ", " +
+            "testContent")
+            .participants(ImmutableSet.of(participant)));
+        verify(javaMailSender).send((MimeMessage) messageCaptor.capture());
+        MimeMessage message = (MimeMessage) messageCaptor.getValue();
+        assertThat(message.getSubject()).isEqualTo("John, Smith, Auckland, Software Engineer, Java, 23, 1, testSubject");
+        assertThat(message.getAllRecipients()[0].toString()).isEqualTo("participant@email.com");
+        assertThat(message.getFrom()[0].toString()).isEqualTo("user@email.com");
+        assertThat(message.getContent()).isInstanceOf(String.class);
+        assertThat(message.getContent().toString()).isEqualTo("John, Smith, Auckland, Software Engineer, Java, 23, 1, testContent");
+        assertThat(message.getDataHandler().getContentType()).isEqualTo("text/plain; charset=UTF-8");
+    }
 }

--- a/src/test/java/org/project36/qualopt/web/rest/EmailTemplateResourceIntTest.java
+++ b/src/test/java/org/project36/qualopt/web/rest/EmailTemplateResourceIntTest.java
@@ -1,20 +1,5 @@
 package org.project36.qualopt.web.rest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.List;
-
-import javax.persistence.EntityManager;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +21,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 /**
  * Test class for the EmailResource REST controller.
  *
@@ -47,7 +41,7 @@ public class EmailTemplateResourceIntTest {
 
     @Autowired
     private EmailTemplateRepository emailTemplateRepository;
-    
+
     @Autowired
     private UserRepository userRepository;
 
@@ -69,7 +63,7 @@ public class EmailTemplateResourceIntTest {
     private User defaultUser ;
 
     private static final String BADUSERLOGIN = "0";
-    
+
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
@@ -85,38 +79,35 @@ public class EmailTemplateResourceIntTest {
      *
      * This is a static method, as tests for other entities might also need it,
      * if they test an entity which requires the current entity.
-     * 
+     *
      * Associate the email template to user 4;
      */
     public static EmailTemplate createEntity(EntityManager em) {
         EmailTemplate emailTemplate = new EmailTemplate();
         //Email template name cannot be null.
         emailTemplate.setName("testTemplate");
-        
+
         return emailTemplate;
     }
-    
+
     /**
      * Create a default user for testing purpose.
-     * 
+     *
      * The user has all of its mandatory field set.
-     * @param id
-     * @return
      */
     public static User createDefaultUser() {
     	User user = new User();
     	user.setLogin("AAAA");
-    	//the password field is a hash of 60 characters. 
+    	//the password field is a hash of 60 characters.
     	user.setPassword("$2a$10$VEjxo0jq2YG9Rbk2HmX9S.k1uZBGYUHdUcid3g/vfiEl7lwWgOH/K");
     	user.setActivated(true);
-    	
     	return user;
     }
 
     @Before
     public void initTest() {
         emailTemplate = createEntity(em);
-        
+
     	User user = createDefaultUser();
     	defaultUser = userRepository.saveAndFlush(user);
         emailTemplate.setUser(defaultUser);
@@ -177,13 +168,13 @@ public class EmailTemplateResourceIntTest {
         emailTemplateRepository.saveAndFlush(emailTemplate);
 
         String userLogin = emailTemplateRepository.findAll().iterator().next().getUser().getLogin();
-        
+
         // Get the email template list
         restEmailMockMvc.perform(get("/api/emailTemplates/{userLogin}", userLogin))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.[*].id").value(hasItem(emailTemplate.getId().intValue())));
-        
+
         List<EmailTemplate> emailTemplateListForAnotherUser = emailTemplateRepository.findAllByUserLogin(BADUSERLOGIN);
         List<EmailTemplate> emailTemplateListForOnlyUser = emailTemplateRepository.findAllByUserLogin(userLogin);
         assertThat(emailTemplateListForAnotherUser).hasSize(0);

--- a/src/test/java/org/project36/qualopt/web/rest/ParticipantResourceIntTest.java
+++ b/src/test/java/org/project36/qualopt/web/rest/ParticipantResourceIntTest.java
@@ -160,7 +160,6 @@ public class ParticipantResourceIntTest {
         participant.setEmail(null);
 
         // Create the Participant, which fails.
-
         restParticipantMockMvc.perform(post("/api/participants")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
             .content(TestUtil.convertObjectToJsonBytes(participant)))
@@ -324,7 +323,7 @@ public class ParticipantResourceIntTest {
         .andExpect(jsonPath("$.numberOfContributions").value(DEFAULT_NUMBER_OF_CONTRIBUTIONS))
         .andExpect(jsonPath("$.numberOfRepositories").value(DEFAULT_NUMBER_OF_REPOSITORIES));
     }
-    
+
     /**
     * This is a test to see if a participant that is created is defaulted to be opted-in to future
     * studies. The participant is saved, queried from the database and then the value is checked.
@@ -334,7 +333,7 @@ public class ParticipantResourceIntTest {
     public void testDefaultOptIn() throws Exception {
         // Initialize the database
         participantRepository.saveAndFlush(participant);
-        
+
         // Check that the participant has default opted-in
         restParticipantMockMvc.perform(get("/api/participants/{id}", participant.getId()))
         .andExpect(status().isOk())

--- a/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
+++ b/src/test/java/org/project36/qualopt/web/rest/StudyResourceIntTest.java
@@ -1,18 +1,5 @@
 package org.project36.qualopt.web.rest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.List;
-
-import javax.persistence.EntityManager;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +21,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
  * Test class for the StudyResource REST controller.


### PR DESCRIPTION
This pull request fixes issue #28 

As part of the fix, the participants can now have first names and last names which can be added while a new participant is being created. The user can now send custom emails by inserting tags into the email text which are replaced with personalised information for each study participant. 

@wilmol contributed to this pull request (reviewed the PR and helped to resolve the merge conflicts).

@wilmol and @AprajitGandhi can you please review this pull. 
