### PR TITLE
chore(ci): add circleci config - testing java and node code #143

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+# Java Maven CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+#
+version: 2
+jobs:
+  java:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: ./mvnw dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+
+      # run tests!
+      - run: ./mvnw clean test
+
+  node:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-js-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-js
+
+      - run: yarn
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-js-{{ checksum "package.json" }}
+
+      - run: yarn test
+
+
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - java
+      - node


### PR DESCRIPTION
This PR closes issues #143 

For CircleCI to start testing builds on this fork, @kblincoe needs to authorise circleci to access this repo. To do this, log into circleci and click on "Add Projects" in the left sidebar, and find this project. This will start a default (un-configured) build which will fail, but once this PR is merged, the correct configuration will be used. Once this is happened, the build will still fail, but that is because the JS tests are currently failing as of writing.

Steps to test:

1. Branch off this branch in the kblincoe repository
2. Commit some failing code, and the PR should indicate a failing status
3. Fix the failing code, and after committing and pushing the PR should indicate a passing status